### PR TITLE
android final checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,5 @@ AWS_DEFAULT_REGION=us-east-1
 APPLE_KEYS_DYNAMO_TABLE_NAME=attestation-gateway-apple-keys # Table name for .env.example must match in tests/aws-seed.sh
 
 # Android PlayIntegrity
-ANDROID_OUTER_JWE_PRIVATE_KEY="7d5b44298bf959af149a0086d79334e6"
+ANDROID_OUTER_JWE_PRIVATE_KEY="N2Q1YjQ0Mjk4YmY5NTlhZjE0OWEwMDg2ZDc5MzM0ZTY=" # must be base64 encoded
 ANDROID_INNER_JWS_PUBLIC_KEY="MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+D+pCqBGmautdPLe/D8ot+e0/EScv4MgiylljSWZUPzQU0npHMNTO8Z9meOTHa3rORO3c2s14gu+Wc5eKdvoHw=="


### PR DESCRIPTION
With an actual attestation token from staging and real keys, these are the final changes needed for android to work end-to-end:
1. The AES key is base-64 encoded.
2. The inner JWS does not contain an `exp` claim, so the expiration validation is removed.
3. The JWS has the actual claims directly as opposed to a `payload` object