### PR TITLE
chore: allow empty appsDetected for staging app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Protects app integrity through the Attestation Gateway.
 - On macOS you need to install `openssl` if you haven't already: `brew install pkg-config openssl@3`
 - Integration tests require a local KMS version and Redis, use the following commands to run tests,
   ```bash
-  docker compose -f docker-compose.test.yml up
+  docker compose -f tests/docker-compose.test.yml up -d
   cargo test
   ```


### PR DESCRIPTION
Slack context: https://tfh.slack.com/archives/C06TB6X5TMZ/p1743157638216359

for some reason, staging doesn't have this value in the integrity token. temporarily ignoring as it's not used anyway.