### PR TITLE
add app version for Android to tokens & data reports

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -32,6 +32,7 @@ pub fn verify(
             // We do this additional error handling to return the parsed token in the response and be able to log it for analytics purposes
             return Ok(VerificationOutput {
                 success: false,
+                app_version: parsed_token.app_integrity.version_code.clone(),
                 parsed_play_integrity_token: Some(parsed_token),
                 client_exception: Some(client_error.clone()),
             });
@@ -41,6 +42,7 @@ pub fn verify(
 
     Ok(VerificationOutput {
         success: true,
+        app_version: parsed_token.app_integrity.version_code.clone(),
         parsed_play_integrity_token: Some(parsed_token),
         client_exception: None,
     })

--- a/src/apple/mod.rs
+++ b/src/apple/mod.rs
@@ -60,6 +60,7 @@ pub async fn verify_initial_attestation(
         success: true,
         parsed_play_integrity_token: None,
         client_exception: None,
+        app_version: None,
     })
 }
 
@@ -114,6 +115,7 @@ pub async fn verify(
         success: true,
         parsed_play_integrity_token: None,
         client_exception: None,
+        app_version: None,
     })
 }
 

--- a/src/kms_jws/tests.rs
+++ b/src/kms_jws/tests.rs
@@ -92,6 +92,7 @@ async fn test_generate_output_token() {
         pass: true,
         out: OutEnum::Pass,
         error: None,
+        app_version: Some("1.25.0".to_string()),
     }
     .generate()
     .unwrap();
@@ -150,4 +151,9 @@ async fn test_generate_output_token() {
         Some(&josekit::Value::String("pass".to_string()))
     );
     assert_eq!(payload.claim("error"), None);
+
+    assert_eq!(
+        payload.claim("app_version"),
+        Some(&josekit::Value::String("1.25.0".to_string()))
+    );
 }

--- a/src/routes/generate_token.rs
+++ b/src/routes/generate_token.rs
@@ -179,6 +179,7 @@ async fn verify_android_or_apple_integrity(
         aud: aud.to_string(),
         internal_debug_info: None,
         play_integrity: None,
+        app_version: None,
     };
 
     let verify_result = match verification_input {
@@ -224,6 +225,7 @@ async fn verify_android_or_apple_integrity(
 
     report.play_integrity = verify_result.parsed_play_integrity_token;
     report.pass = verify_result.success;
+    report.app_version = verify_result.app_version;
     report.out = if verify_result.success {
         OutEnum::Pass
     } else {
@@ -275,6 +277,7 @@ async fn process_and_finalize_report(
         pass: report.pass,
         out: report.out,
         error: None, // TODO: Implement in the future (see L76)
+        app_version: report.app_version.clone(),
     }
     .generate()?;
 

--- a/tests/generate_token_integration.rs
+++ b/tests/generate_token_integration.rs
@@ -267,6 +267,11 @@ async fn test_android_e2e_success() {
         payload.claim("out"),
         Some(&josekit::Value::String("pass".to_string()))
     );
+
+    assert_eq!(
+        payload.claim("app_version"),
+        Some(&josekit::Value::String("25700".to_string()))
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
The `app_version` for Android apps will now be included in the output JWS for attestation gateway, which may help downstream services enforce certain app versions. The `app_version` will also be logged as a `DataReport`