### PR TITLE
generate random report ID for kinesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "uuid",
  "x509-parser",
 ]
 
@@ -3350,9 +3351,12 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tokio = { version = "1.44.2", features = ["full"] }
 tower-http = { version = "0.5.2", features = ["compression-br", "trace", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json"] }
+uuid = { version = "1.16.0", default-features = false, features = ["v4"] }
 x509-parser = "0.16.0"
 
 [build-dependencies]

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -1,6 +1,5 @@
 use crate::utils::DataReport;
 use aws_sdk_kinesis::{primitives::Blob, Client as KinesisClient};
-use serde_json::to_vec;
 
 /// Reports a parsed event to a Kinesis stream for debugging and monitoring purposes
 ///
@@ -11,10 +10,10 @@ pub async fn send_kinesis_stream_event(
     stream_arn: &str,
     data_report: &DataReport,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let partition_key: &str = "request_hash";
+    let partition_key: &str = "id";
 
     // Serialize DataReport to JSON
-    let payload_bytes = to_vec(data_report)?;
+    let payload_bytes = data_report.as_vec()?;
 
     // Send the serialized data to Kinesis
     kinesis_client


### PR DESCRIPTION
This introduces a random ID generation for Kinesis reports as the `request_hash` gets sanitized.