### PR TITLE
improve logging & another whitelist

### DIFF
--- a/src/android/integrity_token_data.rs
+++ b/src/android/integrity_token_data.rs
@@ -339,6 +339,14 @@ impl PlayIntegrityToken {
                     internal_debug_info: "PlayProtectVerdict reported as HighRisk".to_string(),
                 }));
             }
+
+            // FIXME: Temporary whitelist for debugging purposes
+            if let Some(version_code) = &self.app_integrity.version_code {
+                if version_code == "2088400" {
+                    return Ok(());
+                }
+            }
+
             // For staging & dev apps, allow empty apps_detected, while we're debugging an issue.
             let allow_empty_apps_detected = [
                 BundleIdentifier::AndroidStageWorldApp,
@@ -346,7 +354,7 @@ impl PlayIntegrityToken {
             ]
             .contains(bundle_identifier);
             if value.app_access_risk_verdict.apps_detected.is_none() && !allow_empty_apps_detected {
-                // https://developer.android.com/google/play/integrity/verdicts#environment-details-fields:
+                // https://developer.android.com/google/play/integrity/verdicts#environment-details-fields
                 // "appAccessRiskVerdict: {}" => "App access risk is not evaluated because a necessary
                 // requirement was missed. For example, the device was not trustworthy enough."
                 return Err(eyre::eyre!(ClientException {


### PR DESCRIPTION
- Improves expected error logging by downgrading to info. Adds additional key parameters to help debug from logs.
- Adds another whitelist for `appAccessRiskVerdict` as this will be empty if: "The version of your app installed on the device is unknown to Google Play." https://developer.android.com/google/play/integrity/verdicts#environment-details-fields