### PR TITLE
Revert "add ip logging"

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -4,38 +4,12 @@ use aide::axum::{
     routing::{get, post},
     ApiRouter,
 };
-use axum::{
-    body::Body,
-    extract::ConnectInfo,
-    http::Request,
-    middleware::{self, Next},
-    response::Response,
-};
-use std::net::SocketAddr;
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
 mod generate_token;
 mod health;
 mod jwks;
-
-async fn log_ip_middleware(req: Request<Body>, next: Next) -> Response {
-    let method = req.method().clone();
-    let uri = req.uri().clone();
-
-    let client_ip =
-        if let Some(ConnectInfo(addr)) = req.extensions().get::<ConnectInfo<SocketAddr>>() {
-            addr.to_string()
-        } else {
-            "unknown".to_string()
-        };
-
-    let span = tracing::info_span!("request", "network.client.ip" = %client_ip, method = %method, path = %uri);
-
-    let _guard = span.enter();
-
-    next.run(req).await
-}
 
 #[must_use]
 pub fn get_timeout_layer() -> TimeoutLayer {
@@ -47,7 +21,6 @@ pub fn handler() -> ApiRouter {
         .api_route("/g", post(generate_token::handler))
         .api_route("/.well-known/jwks.json", get(jwks::handler))
         .api_route("/health", get(health::handler))
-        .route_layer(middleware::from_fn(log_ip_middleware))
         .layer(TraceLayer::new_for_http()) // adds HTTP tracing & context to all routes
         .layer(get_timeout_layer())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,10 +55,7 @@ pub async fn start(
         .expect("Failed to bind address");
 
     println!("😈 Attestation gateway started on http://{address}");
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await
-    .expect("Failed to start server");
+    axum::serve(listener, app.into_make_service())
+        .await
+        .expect("Failed to start server");
 }


### PR DESCRIPTION
Reverts worldcoin/attestation-gateway#81

this introduced a logging issue, reverting. [logs](https://app.datadoghq.com/logs?query=service:attestation-gateway%20status:info&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host,service&event=AwAAAZaOrTu4M3rDmQAAABhBWmFPclVBRkFBQ2doNzljMk5YQ2lRQkgAAAAkMDE5NjhlYWUtY2JlNC00NjMyLWEwYWQtNDMxZmQ0NzNjYjk5AAAEUw&fromUser=true&messageDisplay=inline&storage=hot&stream_sort=desc&viz=stream&from_ts=1746049336188&to_ts=1746050236188&live=true)