### PR TITLE
Log device_recognition_verdict when it does not MEETS_DEVICE_INTEGRITY

### DIFF
--- a/src/android/integrity_token_data.rs
+++ b/src/android/integrity_token_data.rs
@@ -641,7 +641,7 @@ mod tests {
             ClientException {
                 code: ErrorCode::IntegrityFailed,
                 internal_debug_info:
-                    "device_recognition_verdict does not contain MEETS_DEVICE_INTEGRITY. Legacy device integrity has the following verdicts: [].".to_string()
+                    "device_recognition_verdict does not contain MEETS_DEVICE_INTEGRITY. Device recognition verdict: []. Legacy device integrity has the following verdicts: [].".to_string()
             }
         );
 
@@ -654,7 +654,7 @@ mod tests {
             ClientException {
                 code: ErrorCode::IntegrityFailed,
                 internal_debug_info:
-                    "device_recognition_verdict does not contain MEETS_DEVICE_INTEGRITY. Legacy device integrity has the following verdicts: [].".to_string()
+                    "device_recognition_verdict does not contain MEETS_DEVICE_INTEGRITY. Device recognition verdict: []. Legacy device integrity has the following verdicts: [].".to_string()
             }
         );
     }


### PR DESCRIPTION
Just adding a log for the whole device_recognition_verdict when device does not MEETS_DEVICE_INTEGRITY.