### PR TITLE
Allow client to set token exp

### DIFF
--- a/attestation-gateway/src/nonces/token_details.rs
+++ b/attestation-gateway/src/nonces/token_details.rs
@@ -5,25 +5,22 @@ use std::time::{Duration, SystemTime};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TokenDetails {
     pub aud: String,
-
-    #[serde(with = "chrono::serde::ts_milliseconds")]
-    pub exp: DateTime<Utc>,
+    pub exp_max: i64,
 }
 
 impl TokenDetails {
     #[must_use]
     pub fn from_aud(aud: String) -> Self {
+        let now = DateTime::<Utc>::from(SystemTime::now());
         let ttl = Duration::from_mins(5);
-        let exp = DateTime::<Utc>::from(SystemTime::now()) + ttl;
+        let exp_max = (now + ttl).timestamp();
 
-        Self { aud, exp }
+        Self { aud, exp_max }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use chrono::SubsecRound;
-
     use super::*;
 
     #[test]
@@ -31,7 +28,7 @@ mod tests {
         let token_details = TokenDetails::from_aud("android".to_string());
 
         assert_eq!(token_details.aud, "android");
-        assert!(token_details.exp > DateTime::<Utc>::from(SystemTime::now()));
+        assert!(token_details.exp_max > DateTime::<Utc>::from(SystemTime::now()).timestamp());
     }
 
     #[test]
@@ -40,19 +37,16 @@ mod tests {
         let json = serde_json::to_string(&token_details).unwrap();
 
         assert!(json.contains("\"aud\":\"android\""));
-        assert!(json.contains("\"exp\":"));
+        assert!(json.contains("\"exp_max\":"));
     }
 
     #[test]
     fn test_deserialize_from_json() {
-        let json = r#"{"aud":"test-audience","exp":1000000000000}"#;
+        let json = r#"{"aud":"test-audience","exp_max":1000000000}"#;
         let token_details: TokenDetails = serde_json::from_str(json).unwrap();
 
         assert_eq!(token_details.aud, "test-audience");
-        assert_eq!(
-            token_details.exp,
-            DateTime::parse_from_rfc3339("2001-09-09T01:46:40.000Z").unwrap()
-        );
+        assert_eq!(token_details.exp_max, 1000000000);
     }
 
     #[test]
@@ -62,6 +56,6 @@ mod tests {
         let deserialized: TokenDetails = serde_json::from_str(&json).unwrap();
 
         assert_eq!(deserialized.aud, original.aud);
-        assert_eq!(deserialized.exp, original.exp.trunc_subsecs(3));
+        assert_eq!(deserialized.exp_max, original.exp_max);
     }
 }

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -26,6 +26,7 @@ use crate::{
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub struct Request {
     pub nonce: String,
+    pub exp: Option<i64>,
     pub app_version: String,
     pub bundle_identifier: BundleIdentifier,
     pub apple_attestation: Option<String>,
@@ -45,7 +46,7 @@ pub struct IntegrityTokenPayload {
     pub aud: String,
     pub cnf: Vec<u8>,
     pub pass: bool,
-    pub exp: DateTime<Utc>,
+    pub exp: i64,
 }
 
 impl IntegrityTokenPayload {
@@ -78,7 +79,11 @@ impl IntegrityTokenPayload {
         let mut payload = JwtPayload::new();
         payload.set_issued_at(&SystemTime::now());
         payload.set_issuer("attestation.worldcoin.org"); // TODO: what about attestation.worldcoin.dev?
-        payload.set_expires_at(&self.exp.into());
+        payload.set_expires_at(
+            &DateTime::<Utc>::from_timestamp(self.exp, 0)
+                .ok_or(eyre::Error::msg("Unreachable exp conversion"))?
+                .into(),
+        );
         payload.set_claim("v", Some(josekit::Value::String(self.v.clone())))?;
         payload.set_claim(
             "app_version",
@@ -202,6 +207,20 @@ pub async fn handler(
         }
     })?;
 
+    let exp = match request.exp {
+        Some(exp) => {
+            if exp > token_details.exp_max {
+                return Err(RequestError {
+                    code: ErrorCode::BadRequest,
+                    details: Some("Exp is greater than token exp max".to_string()),
+                });
+            } else {
+                Ok(exp)
+            }
+        }
+        None => Ok(token_details.exp_max),
+    }?;
+
     let integrity_token = generate_integrity_token(
         &mut redis,
         &aws_config,
@@ -212,7 +231,7 @@ pub async fn handler(
             aud: token_details.aud,
             cnf: device_public_key,
             pass: true,
-            exp: token_details.exp,
+            exp,
         },
     )
     .await?;

--- a/attestation-gateway/src/routes/c.rs
+++ b/attestation-gateway/src/routes/c.rs
@@ -1,5 +1,5 @@
 use axum::{Extension, Json};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 
 use crate::nonces::{NonceDb, TokenDetails};
@@ -13,6 +13,7 @@ pub struct Request {
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub struct Response {
     pub nonce: String,
+    pub token_exp_max: i64,
     pub device_key_expires_at: String,
 }
 
@@ -62,12 +63,18 @@ pub async fn handler(
         }
     })?;
 
-    let device_key_expires_at: chrono::DateTime<Utc> = token_details.exp;
+    let device_key_expires_at =
+        DateTime::<Utc>::from_timestamp(token_details.exp_max, 0).ok_or(RequestError {
+            code: ErrorCode::InternalServerError,
+            details: Some("Failed to generate device key expires at.".to_string()),
+        })?;
+
     let device_key_expires_at =
         device_key_expires_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
     Ok(Json(Response {
         nonce,
+        token_exp_max: token_details.exp_max,
         device_key_expires_at,
     }))
 }


### PR DESCRIPTION
In response to challenge request via `/c` endpoint new field `token_exp_max` is returned. Client may optionally provide custom `exp` during token generation via `/a` endpoint if it isn't higher than `token_exp_max`.