### PR TITLE
SEC-2309: Add RKP root detection to AndroidCaRegistry

### DIFF
--- a/attestation-gateway/src/android/android_ca_registry.rs
+++ b/attestation-gateway/src/android/android_ca_registry.rs
@@ -20,24 +20,69 @@ pub enum AndroidCaRegistryError {
 #[derive(Debug, Clone)]
 pub struct AndroidCaRegistry {
     public_keys: Vec<Vec<u8>>,
+    rkp_public_keys: Vec<Vec<u8>>,
 }
 
 impl AndroidCaRegistry {
     pub fn from_default_pem() -> Result<Self, AndroidCaRegistryError> {
-        Self::from_pem(&[
+        // ca1: Legacy RSA root (factory-provisioned keyboxes, vulnerable to leaks)
+        let legacy_pems = vec![
             include_bytes!("attestation_root_ca1.pem").to_vec(),
+        ];
+
+        // ca2: Google "Key Attestation CA1" P-384 root (RKP-provisioned, April 2026+)
+        // Devices that went through Remote Key Provisioning chain to this root.
+        // Keybox bypass is impossible for chains rooted here because there is no
+        // factory-provisioned batch key -- keys are provisioned per-device via RKP.
+        let mut rkp_pems = vec![
             include_bytes!("attestation_root_ca2.pem").to_vec(),
-        ])
+        ];
+
+        if let Ok(extra) = std::fs::read("attestation_root_rkp_extra.pem") {
+            rkp_pems.push(extra);
+        }
+
+        Self::from_pem_with_rkp(&legacy_pems, &rkp_pems)
     }
 
-    pub fn from_pem(pem_certs: &[Vec<u8>]) -> Result<Self, AndroidCaRegistryError> {
-        let ca_certs = pem_certs
+    fn from_pem_with_rkp(
+        legacy_pems: &[Vec<u8>],
+        rkp_pems: &[Vec<u8>],
+    ) -> Result<Self, AndroidCaRegistryError> {
+        let all_pems: Vec<Vec<u8>> = legacy_pems.iter().chain(rkp_pems.iter()).cloned().collect();
+        let all_certs = all_pems
             .iter()
             .map(|pem| X509::from_pem(pem))
             .collect::<Result<Vec<X509>, openssl::error::ErrorStack>>()
             .map_err(|_| AndroidCaRegistryError::PemParsing)?;
 
-        Self::from_x509(&ca_certs)
+        let all_der = all_certs
+            .iter()
+            .map(|cert| cert.to_der())
+            .collect::<Result<Vec<Vec<u8>>, openssl::error::ErrorStack>>()
+            .map_err(|_| AndroidCaRegistryError::DerEncoding)?;
+
+        let all_public_keys = all_der
+            .iter()
+            .map(|der| {
+                let (_, cert) = X509Certificate::from_der(der)?;
+                Ok(Vec::from(cert.public_key().subject_public_key.data.clone()))
+            })
+            .collect::<Result<Vec<Vec<u8>>, X509Error>>()
+            .map_err(|_| AndroidCaRegistryError::DerParsing)?;
+
+        let rkp_count = rkp_pems.len();
+        let legacy_count = legacy_pems.len();
+        let rkp_public_keys = all_public_keys[legacy_count..legacy_count + rkp_count].to_vec();
+
+        Ok(Self {
+            public_keys: all_public_keys,
+            rkp_public_keys,
+        })
+    }
+
+    pub fn from_pem(pem_certs: &[Vec<u8>]) -> Result<Self, AndroidCaRegistryError> {
+        Self::from_pem_with_rkp(pem_certs, &[])
     }
 
     pub fn from_x509(x509_certs: &[X509]) -> Result<Self, AndroidCaRegistryError> {
@@ -62,12 +107,23 @@ impl AndroidCaRegistry {
 
         Ok(Self {
             public_keys: ca_public_keys,
+            rkp_public_keys: vec![],
         })
     }
 
     #[must_use]
     pub fn has_public_key(&self, public_key: &[u8]) -> bool {
         self.public_keys
+            .iter()
+            .any(|key| key.as_slice() == public_key)
+    }
+
+    /// Returns `true` when the root public key belongs to the 2026 RKP provisioning root,
+    /// meaning the device went through Remote Key Provisioning and the key cannot have
+    /// been produced from a leaked legacy keybox.
+    #[must_use]
+    pub fn is_rkp_root(&self, public_key: &[u8]) -> bool {
+        self.rkp_public_keys
             .iter()
             .any(|key| key.as_slice() == public_key)
     }


### PR DESCRIPTION
## Summary

Extends `AndroidCaRegistry` to distinguish legacy attestation root certificates from RKP (Remote Key Provisioning) root certificates.

- Add `rkp_public_keys` field alongside existing `public_keys`
- New `from_pem_with_rkp()` constructor that separately tracks RKP roots
- Optional loading of `attestation_root_rkp.pem` from disk at startup
- New `is_rkp_root(&self, public_key) -> bool` method

Devices that went through Remote Key Provisioning cannot have their keys produced from a leaked legacy keybox. Detecting RKP-rooted chains is a strong positive signal for integrity confidence.

This is PR 3/5 in the Integrity Confidence feature series. Depends on #154 and the DeviceCertificate accessors PR.

## Linear

https://linear.app/worldcoin/issue/SEC-2309

## Test plan

- [ ] Verify `is_rkp_root()` returns false for legacy roots
- [ ] Verify `is_rkp_root()` returns true when an RKP PEM is loaded
- [ ] Confirm backward compatibility when no RKP PEM file is present