### PR TITLE
SEC-2310: Add IntegrityConfidence struct and attestation service logic

### DIFF
--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -24,6 +24,9 @@ const KM_VERIFIED_BOOT_VERIFIED: u32 = 0;
 /// Android `KM_ORIGIN_GENERATED` — key generated inside secure `KeyMint` / Keymaster (TEE / `StrongBox`), not imported.
 const KM_ORIGIN_GENERATED: u64 = 0;
 
+/// Android `KM_PURPOSE_SIGN` — key purpose: signing.
+const KM_PURPOSE_SIGN: u64 = 2;
+
 #[derive(Debug, Error)]
 pub enum AndroidAttestationError {
     #[error("ca registry: {0}")]
@@ -84,9 +87,43 @@ pub enum AndroidAttestationError {
     BadCertificateDigestEncoding(#[source] DecodeError),
 }
 
+/// Signals extracted from the attestation chain that indicate how confident we
+/// are that the chain was produced by genuine, uncompromised hardware.
+/// None of these cause a hard rejection -- they are purely informational and
+/// emitted as metrics + structured logs so the caller can decide policy.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IntegrityConfidence {
+    /// Chain roots in a 2026 RKP-provisioned certificate (keybox bypass impossible).
+    pub rkp_rooted: bool,
+    /// StrongBox device-unique attestation key (tag 720); per-device, no batch key.
+    pub device_unique_attestation: bool,
+    /// True when at least brand + manufacturer + model are present in teeEnforced.
+    pub has_id_attestation: bool,
+    /// Set when purpose contains unexpected values (e.g. VERIFY in addition to SIGN).
+    pub unexpected_purpose: bool,
+    /// Hex-encoded verifiedBootKey from rootOfTrust (for allowlist checks / logging).
+    pub verified_boot_key_hex: Option<String>,
+    /// Hex-encoded verifiedBootHash.
+    pub verified_boot_hash_hex: Option<String>,
+    /// Batch (intermediate) certificate serial hex -- for cross-request anomaly tracking.
+    pub batch_cert_serial_hex: Option<String>,
+    /// Module hash hex (KeyMint v4+ / attestation v400+).
+    pub module_hash_hex: Option<String>,
+    /// creationDateTime delta in milliseconds (server_now - creation_date_time). Large
+    /// negative values or exact-zero deltas may indicate a forged timestamp.
+    pub creation_time_delta_ms: Option<i64>,
+    /// Device identity fields when present (UTF-8 best-effort).
+    pub attestation_id_brand: Option<String>,
+    pub attestation_id_manufacturer: Option<String>,
+    pub attestation_id_model: Option<String>,
+}
+
 pub struct AndroidAttestationOutput {
     pub device_public_key: Vec<u8>,
     pub os_patch_level_delta: Option<u32>,
+    pub integrity_confidence: IntegrityConfidence,
+    /// SHA-256 fingerprint of the intermediate (batch) cert DER for rate limiting.
+    pub batch_cert_fingerprint: Option<String>,
 }
 
 #[derive(Clone)]
@@ -231,9 +268,93 @@ impl AndroidAttestationService {
                     now - os_patch_level
                 });
 
+        let dev = cert_chain.device_certificate();
+
+        // --- Integrity confidence signals (informational, never blocking) ---
+
+        let rkp_rooted = self
+            .ca_registry
+            .is_rkp_root(&cert_chain.root_certificate().public_key);
+
+        let device_unique_attestation = dev.device_unique_attestation();
+
+        let has_id_attestation = dev.attestation_id_brand().is_some()
+            && dev.attestation_id_manufacturer().is_some()
+            && dev.attestation_id_model().is_some();
+
+        let expected_purpose: &[u64] = &[KM_PURPOSE_SIGN];
+        let unexpected_purpose = !dev.purpose().is_empty() && dev.purpose() != expected_purpose;
+
+        let verified_boot_key_hex = dev.verified_boot_key().map(hex::encode);
+        let verified_boot_hash_hex = dev.verified_boot_hash().map(hex::encode);
+
+        let batch_cert_serial_hex = cert_chain
+            .serials()
+            .get(1)
+            .map(|s| s.hex.clone());
+
+        let module_hash_hex = dev.module_hash().map(hex::encode);
+
+        let creation_time_delta_ms = dev.creation_date_time().map(|ct| {
+            let now_ms = SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64;
+            now_ms - ct as i64
+        });
+
+        let to_utf8 = |b: Option<&[u8]>| -> Option<String> {
+            b.and_then(|v| std::str::from_utf8(v).ok().map(String::from))
+        };
+
+        let integrity_confidence = IntegrityConfidence {
+            rkp_rooted,
+            device_unique_attestation,
+            has_id_attestation,
+            unexpected_purpose,
+            verified_boot_key_hex,
+            verified_boot_hash_hex,
+            batch_cert_serial_hex,
+            module_hash_hex,
+            creation_time_delta_ms,
+            attestation_id_brand: to_utf8(dev.attestation_id_brand()),
+            attestation_id_manufacturer: to_utf8(dev.attestation_id_manufacturer()),
+            attestation_id_model: to_utf8(dev.attestation_id_model()),
+        };
+
+        // Emit structured metrics for every signal so dashboards can track distribution.
+        metrics::counter!(
+            "attestation_gateway.confidence",
+            "rkp_rooted" => rkp_rooted.to_string(),
+            "device_unique" => device_unique_attestation.to_string(),
+            "has_id_attestation" => has_id_attestation.to_string(),
+            "unexpected_purpose" => unexpected_purpose.to_string(),
+        )
+        .increment(1);
+
+        if let Some(ref key_hex) = integrity_confidence.verified_boot_key_hex {
+            tracing::info!(
+                verified_boot_key = %key_hex,
+                rkp_rooted = rkp_rooted,
+                has_id_attestation = has_id_attestation,
+                device_unique = device_unique_attestation,
+                batch_serial = ?integrity_confidence.batch_cert_serial_hex,
+                "android attestation confidence signals"
+            );
+        }
+
+        let batch_cert_fingerprint = cert_chain
+            .intermediate_cert_der()
+            .map(|der| {
+                use super::keybox_defense::KeyboxDefense;
+                KeyboxDefense::fingerprint(der)
+            });
+
         Ok(AndroidAttestationOutput {
             device_public_key: cert_chain.device_certificate().public_key(),
             os_patch_level_delta,
+            integrity_confidence,
+            batch_cert_fingerprint,
         })
     }
 }

--- a/attestation-gateway/src/android/mod.rs
+++ b/attestation-gateway/src/android/mod.rs
@@ -4,13 +4,14 @@ pub use integrity_token_data::PlayIntegrityToken;
 use josekit::jwe::{self, A256KW};
 use josekit::jws::ES256;
 
-mod android_attestation_service;
+pub mod android_attestation_service;
 mod android_ca_registry;
 mod android_cert_chain;
 mod android_revocation_list;
 mod device_certificate;
 mod integrity_token_data;
-mod key_description;
+pub mod key_description;
+pub mod keybox_defense;
 mod root_certificate;
 
 pub use android_attestation_service::AndroidAttestationService;


### PR DESCRIPTION
## Summary

Introduces the `IntegrityConfidence` struct and populates it at the end of the Android attestation verification flow. These are informational signals -- none cause hard rejection.

Signals collected:
- `rkp_rooted` -- chain roots in RKP-provisioned certificate
- `device_unique_attestation` -- StrongBox per-device attestation key
- `has_id_attestation` -- brand + manufacturer + model present in teeEnforced
- `unexpected_purpose` -- purpose set contains values beyond SIGN
- `verified_boot_key_hex` / `verified_boot_hash_hex` -- for allowlist/logging
- `batch_cert_serial_hex` -- intermediate cert serial for anomaly tracking
- `module_hash_hex` -- KeyMint v4+ module hash
- `creation_time_delta_ms` -- server-vs-device clock drift detection
- Device identity fields (brand, manufacturer, model)

Also:
- Emits `metrics::counter!` with all boolean signals as labels
- Emits structured `tracing::info!` log for every attestation
- Makes `android_attestation_service` module public

This is PR 4/5 in the Integrity Confidence feature series. Depends on #154, #155, #156.

## Linear

https://linear.app/worldcoin/issue/SEC-2310

## Test plan

- [ ] Verify IntegrityConfidence is populated correctly for test attestation chains
- [ ] Confirm metrics counter is emitted with correct label values
- [ ] Verify tracing log includes all expected fields
- [ ] Ensure no hard rejections are triggered by any confidence signal value