### PR TITLE
SEC-2276: integrity confidence signals + structured observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -97,9 +97,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -193,6 +193,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +243,7 @@ dependencies = [
  "eyre",
  "hex",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "josekit",
  "jwtk",
  "metrics",
@@ -240,7 +251,7 @@ dependencies = [
  "mime",
  "mockito",
  "openssl",
- "rand 0.10.0",
+ "rand 0.10.1",
  "redis",
  "regex",
  "reqwest",
@@ -279,9 +290,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.14"
+version = "1.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -299,7 +310,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "ring",
+ "sha1",
  "time",
  "tokio",
  "tracing",
@@ -309,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -321,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -331,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -343,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede2ddc593e6c8acc6ce3358c28d6677a6dc49b65ba4b37a2befe14a11297e75"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -369,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.107.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561bf86e858a2759c6876b517b13f3f4051a6484abbb0d8a1f4dfc5d902cc85a"
+checksum = "0c597424385739456cd04535982831c15bd58f97ca28c5bcb232c0d730d5cb39"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -393,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51eec5527a16f24cc6826d0d34b93ae57b2c40dc64eaadb7f430532b7ef29126"
+checksum = "3756f0a1e0dd2974b83bea6e4967dad47f832c023009468b0bf8efa43e4ed4f9"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -418,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.102.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b682ef733ec24c300b11cec2df9bfea7ee4bf48ab2030c832e27db92b69c68"
+checksum = "c41ae6a33da941457e89075ef8ca5b4870c8009fe4dceeba82fce2f30f313ac6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -442,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.95.0"
+version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c5ff27c6ba2cbd95e6e26e2e736676fdf6bcf96495b187733f521cfe4ce448"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -466,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.97.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d186f1e5a3694a188e5a0640b3115ccc6e084d104e16fd6ba968dca072ffef8"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -490,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.99.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acba7c62f3d4e2408fa998a3a8caacd8b9a5b5549cf36e2372fbdae329d5449"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -515,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -595,13 +606,13 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -682,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -717,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.13"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0470cc047657c6e286346bdf10a8719d26efd6a91626992e0e64481e44323e96"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -742,7 +753,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -852,9 +863,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -916,18 +927,18 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7aff0c323415907f37007d645d7499c378df47efb3e33ffc1f397fa4e549b2e"
+checksum = "5ca08f6db9f0c963249cf23a27820f9d973d2acaad4d6bfaeb858b58ebd58a6a"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -955,7 +966,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1001,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1046,6 +1057,15 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1123,9 +1143,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1143,12 +1163,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1167,11 +1187,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1192,11 +1211,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1303,6 +1322,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1486,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1530,7 +1570,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1547,7 +1587,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1566,7 +1606,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1601,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1719,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1734,7 +1774,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1757,16 +1796,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1781,7 +1819,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1801,12 +1839,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1840,12 +1878,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1853,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1866,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1880,15 +1919,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1900,15 +1939,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1971,12 +2010,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1989,9 +2028,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2017,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2050,10 +2089,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2118,9 +2159,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2130,9 +2171,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2221,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2243,11 +2284,11 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2341,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2396,15 +2437,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2434,18 +2475,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2459,6 +2500,12 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2503,9 +2550,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -2515,9 +2562,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2568,8 +2615,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.5.10",
+ "rustls 0.23.38",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2578,17 +2625,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2606,16 +2653,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2634,9 +2681,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2644,13 +2691,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2674,18 +2721,19 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redis"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe7f6e08ce1c6a9b21684e643926f6fc3b683bc006cb89afd72a5e0eb16e3a2"
+checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
 dependencies = [
  "arc-swap",
  "arcstr",
+ "async-lock",
  "backon",
  "bytes",
  "cfg-if",
@@ -2699,7 +2747,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -2785,8 +2833,8 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2796,7 +2844,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2831,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2880,15 +2928,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -2927,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2960,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2974,7 +3022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -3063,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3124,7 +3172,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3170,15 +3218,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3189,11 +3237,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3223,6 +3271,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -3269,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -3303,12 +3362,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3383,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -3476,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3486,9 +3545,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3501,9 +3560,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3511,16 +3570,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3553,7 +3612,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -3677,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3773,9 +3832,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3841,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3854,23 +3913,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3878,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3891,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3915,7 +3970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3928,15 +3983,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4215,7 +4270,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4246,7 +4301,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4265,7 +4320,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4277,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
@@ -4312,9 +4367,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4323,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4335,18 +4390,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4355,18 +4410,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4382,9 +4437,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4393,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4404,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/attestation-gateway/Cargo.toml
+++ b/attestation-gateway/Cargo.toml
@@ -47,7 +47,7 @@ thiserror.workspace = true
 tokio = { version = "1.50.0", features = ["full"] }
 tower-http = { version = "0.6.8", features = ["compression-br", "trace", "timeout"] }
 tracing = { version = "0.1.44", features = ["log"] }
-tracing-subscriber = { version = "0.3.22", default-features = false, features = ["fmt", "json"] }
+tracing-subscriber = { version = "0.3.22", default-features = false, features = ["fmt", "json", "env-filter"] }
 uuid = { version = "1.21.0", default-features = false, features = ["v4"] }
 x509-parser = "0.18.1"
 

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -112,18 +112,39 @@ pub struct IntegrityConfidence {
     /// creationDateTime delta in milliseconds (server_now - creation_date_time). Large
     /// negative values or exact-zero deltas may indicate a forged timestamp.
     pub creation_time_delta_ms: Option<i64>,
+    /// Hardware-bound unique ID (HMAC_SHA256 with device secret). 128-bit, rotates every 30 days.
+    /// Empty when the app doesn't request INCLUDE_UNIQUE_ID.
+    pub unique_id_hex: Option<String>,
     /// Device identity fields when present (UTF-8 best-effort).
     pub attestation_id_brand: Option<String>,
+    pub attestation_id_device: Option<String>,
+    pub attestation_id_product: Option<String>,
+    pub attestation_id_serial: Option<String>,
+    pub attestation_id_imei: Option<String>,
+    pub attestation_id_meid: Option<String>,
     pub attestation_id_manufacturer: Option<String>,
     pub attestation_id_model: Option<String>,
+    pub attestation_id_second_imei: Option<String>,
+    /// Android OS version as encoded integer (e.g. 160000 = Android 16.0.0).
+    pub os_version: Option<u64>,
+    /// Vendor-specific patch level (YYYYMMDD).
+    pub vendor_patch_level: Option<u64>,
+    /// Boot image patch level (YYYYMMDD).
+    pub boot_patch_level: Option<u64>,
+    /// Maximum number of times the key can be used.
+    pub usage_count_limit: Option<u64>,
+    /// Key algorithm (1=RSA, 3=EC).
+    pub algorithm: Option<u64>,
+    /// Key size in bits.
+    pub key_size: Option<u64>,
+    /// EC curve (0=P-224, 1=P-256, 2=P-384, 3=P-521).
+    pub ec_curve: Option<u64>,
 }
 
 pub struct AndroidAttestationOutput {
     pub device_public_key: Vec<u8>,
     pub os_patch_level_delta: Option<u32>,
     pub integrity_confidence: IntegrityConfidence,
-    /// SHA-256 fingerprint of the intermediate (batch) cert DER for rate limiting.
-    pub batch_cert_fingerprint: Option<String>,
 }
 
 #[derive(Clone)]
@@ -167,40 +188,72 @@ impl AndroidAttestationService {
         app_version: &String,
         bundle_identifier: &BundleIdentifier,
     ) -> Result<AndroidAttestationOutput, AndroidAttestationError> {
+        tracing::info!(
+            cert_chain_len = base64_cert_chain.len(),
+            bundle_identifier = %bundle_identifier,
+            "android verify: starting verification"
+        );
+
         let cert_chain = AndroidCertChain::from_base64(base64_cert_chain, &self.ca_registry)
             .map_err(AndroidAttestationError::CertChain)?;
 
-        if cert_chain
+        let revoked = cert_chain
             .serials()
             .iter()
-            .any(|s| s.is_revoked(&self.revocation_list))
-        {
+            .any(|s| s.is_revoked(&self.revocation_list));
+        tracing::info!(
+            revoked = revoked,
+            serial_count = cert_chain.serials().len(),
+            "android verify: revocation check"
+        );
+        if revoked {
             return Err(AndroidAttestationError::CertificateRevoked);
         }
 
-        if !self
+        let has_valid_root = self
             .ca_registry
-            .has_public_key(&cert_chain.root_certificate().public_key)
-        {
+            .has_public_key(&cert_chain.root_certificate().public_key);
+        let is_rkp = self
+            .ca_registry
+            .is_rkp_root(&cert_chain.root_certificate().public_key);
+        tracing::info!(
+            has_valid_root = has_valid_root,
+            is_rkp_root = is_rkp,
+            "android verify: CA root check"
+        );
+        if !has_valid_root {
             return Err(AndroidAttestationError::InvalidCaRoot);
         }
 
-        if cert_chain.device_certificate().attestation_challenge()
-            != format!("n={nonce},av={app_version}")
-        {
+        let expected_challenge = format!("n={nonce},av={app_version}");
+        let actual_challenge = cert_chain.device_certificate().attestation_challenge();
+        tracing::info!(
+            expected_challenge = %expected_challenge,
+            actual_challenge = %actual_challenge,
+            "android verify: challenge comparison"
+        );
+        if actual_challenge != expected_challenge {
             return Err(AndroidAttestationError::InvalidChallenge);
         }
 
+        let attestation_security_level =
+            cert_chain.device_certificate().attestation_security_level();
+        let key_mint_security_level = cert_chain.device_certificate().key_mint_security_level();
+        tracing::info!(
+            attestation_security_level = attestation_security_level,
+            key_mint_security_level = key_mint_security_level,
+            levels_match = (attestation_security_level == key_mint_security_level),
+            "android verify: security levels"
+        );
+
         if !matches!(
-            cert_chain.device_certificate().attestation_security_level(),
+            attestation_security_level,
             KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT | KM_SECURITY_LEVEL_STRONG_BOX
         ) {
             return Err(AndroidAttestationError::LowSecurityLevel);
         }
 
-        if cert_chain.device_certificate().key_mint_security_level()
-            != cert_chain.device_certificate().attestation_security_level()
-        {
+        if key_mint_security_level != attestation_security_level {
             return Err(AndroidAttestationError::InconsistentSecurityLevels);
         }
 
@@ -209,14 +262,20 @@ impl AndroidAttestationService {
             .verified_boot_state()
             .ok_or(AndroidAttestationError::MissingRootOfTrust)?;
 
-        if verified_boot_state != KM_VERIFIED_BOOT_VERIFIED {
-            return Err(AndroidAttestationError::BootNotVerified);
-        }
-
         let device_locked = cert_chain
             .device_certificate()
             .device_locked()
             .ok_or(AndroidAttestationError::MissingRootOfTrust)?;
+
+        tracing::info!(
+            verified_boot_state = verified_boot_state,
+            device_locked = device_locked,
+            "android verify: boot state and device lock"
+        );
+
+        if verified_boot_state != KM_VERIFIED_BOOT_VERIFIED {
+            return Err(AndroidAttestationError::BootNotVerified);
+        }
 
         if !device_locked {
             return Err(AndroidAttestationError::DeviceNotLocked);
@@ -226,6 +285,12 @@ impl AndroidAttestationService {
             .device_certificate()
             .key_origin()
             .ok_or(AndroidAttestationError::MissingKeyOrigin)?;
+
+        tracing::info!(
+            key_origin = key_origin,
+            expected = KM_ORIGIN_GENERATED,
+            "android verify: key origin"
+        );
 
         if key_origin != KM_ORIGIN_GENERATED {
             return Err(AndroidAttestationError::KeyNotGeneratedInSecureHardware);
@@ -240,21 +305,67 @@ impl AndroidAttestationService {
             .certificate_sha256_digest_base64()
             .ok_or(AndroidAttestationError::MissingCertificateDigest)?;
 
-        let expected_attestation_signature_digest = Base64
+        let expected = Base64
             .decode(expected_attestation_signature_digest)
             .map_err(AndroidAttestationError::BadCertificateDigestEncoding)?;
 
-        if !attestation_signature_digests.contains(&expected_attestation_signature_digest) {
+        let digests_hex: Vec<String> = attestation_signature_digests
+            .iter()
+            .map(|d| Base64.encode(d))
+            .collect();
+        tracing::info!(
+            found_digests = ?digests_hex,
+            expected_digest = %expected_attestation_signature_digest,
+            "android verify: signature digest comparison"
+        );
+
+        let prod_match = attestation_signature_digests.contains(&expected);
+
+        // Optional staging affordance: when
+        // `ATTESTATION_GATEWAY_ACCEPT_ALT_SIGNING_CERT=1` is set on the
+        // staging gateway, also accept the debug/dev World App signing cert
+        // for the staging bundle. Disabled by default; bundles other than
+        // `AndroidStageWorldApp` are unaffected.
+        let alt_match = if std::env::var("ATTESTATION_GATEWAY_ACCEPT_ALT_SIGNING_CERT")
+            .ok()
+            .as_deref()
+            == Some("1")
+        {
+            bundle_identifier
+                .certificate_sha256_digest_base64_alt()
+                .and_then(|alt| Base64.decode(alt).ok())
+                .map_or(false, |alt_decoded| {
+                    attestation_signature_digests.contains(&alt_decoded)
+                })
+        } else {
+            false
+        };
+
+        if prod_match {
+            tracing::info!("android verify: production signature digest matched");
+        } else if alt_match {
+            tracing::info!("android verify: alt/debug signature digest matched");
+        } else {
+            tracing::warn!(
+                found_digests = ?digests_hex,
+                expected_digest = %expected_attestation_signature_digest,
+                alt_digest = ?bundle_identifier.certificate_sha256_digest_base64_alt(),
+                "android verify: no signature digest matched"
+            );
             return Err(AndroidAttestationError::InvalidAttestationSignatureDigest);
         }
 
         let package_names = cert_chain.device_certificate().package_names();
+        tracing::info!(
+            package_names = ?package_names,
+            "android verify: package names in cert"
+        );
         if package_names.is_empty() {
             return Err(AndroidAttestationError::MissingPackageName);
         }
 
-        let expected = bundle_identifier.to_string();
-        if !package_names.iter().any(|name| name == &expected) {
+        let expected_pkg = bundle_identifier.to_string();
+        if !package_names.iter().any(|name| name == &expected_pkg) {
             return Err(AndroidAttestationError::InvalidPackageName);
         }
 
@@ -270,11 +381,17 @@ impl AndroidAttestationService {
 
         let dev = cert_chain.device_certificate();
 
+        let attestation_version = dev.attestation_version();
+        tracing::info!(
+            attestation_version = attestation_version,
+            os_patch_level = ?dev.os_patch_level(),
+            os_patch_level_delta = ?os_patch_level_delta,
+            "android verify: attestation version and patch level"
+        );
+
         // --- Integrity confidence signals (informational, never blocking) ---
 
-        let rkp_rooted = self
-            .ca_registry
-            .is_rkp_root(&cert_chain.root_certificate().public_key);
+        let rkp_rooted = is_rkp;
 
         let device_unique_attestation = dev.device_unique_attestation();
 
@@ -288,10 +405,7 @@ impl AndroidAttestationService {
         let verified_boot_key_hex = dev.verified_boot_key().map(hex::encode);
         let verified_boot_hash_hex = dev.verified_boot_hash().map(hex::encode);
 
-        let batch_cert_serial_hex = cert_chain
-            .serials()
-            .get(1)
-            .map(|s| s.hex.clone());
+        let batch_cert_serial_hex = cert_chain.serials().get(1).map(|s| s.hex.clone());
 
         let module_hash_hex = dev.module_hash().map(hex::encode);
 
@@ -307,19 +421,106 @@ impl AndroidAttestationService {
             b.and_then(|v| std::str::from_utf8(v).ok().map(String::from))
         };
 
+        let unique_id_hex = dev.unique_id().map(hex::encode);
+
+        let attestation_id_brand = to_utf8(dev.attestation_id_brand());
+        let attestation_id_device = to_utf8(dev.attestation_id_device());
+        let attestation_id_product = to_utf8(dev.attestation_id_product());
+        let attestation_id_serial = to_utf8(dev.attestation_id_serial());
+        let attestation_id_imei = to_utf8(dev.attestation_id_imei());
+        let attestation_id_meid = to_utf8(dev.attestation_id_meid());
+        let attestation_id_manufacturer = to_utf8(dev.attestation_id_manufacturer());
+        let attestation_id_model = to_utf8(dev.attestation_id_model());
+        let attestation_id_second_imei = to_utf8(dev.attestation_id_second_imei());
+
+        tracing::info!(
+            rkp_rooted = rkp_rooted,
+            device_unique_attestation = device_unique_attestation,
+            has_id_attestation = has_id_attestation,
+            unexpected_purpose = unexpected_purpose,
+            unique_id = ?unique_id_hex,
+            purpose = ?dev.purpose(),
+            verified_boot_key = ?verified_boot_key_hex,
+            verified_boot_hash = ?verified_boot_hash_hex,
+            batch_cert_serial = ?batch_cert_serial_hex,
+            module_hash = ?module_hash_hex,
+            creation_time_delta_ms = ?creation_time_delta_ms,
+            attestation_id_brand = ?attestation_id_brand,
+            attestation_id_device = ?attestation_id_device,
+            attestation_id_product = ?attestation_id_product,
+            attestation_id_manufacturer = ?attestation_id_manufacturer,
+            attestation_id_model = ?attestation_id_model,
+            "android verify: integrity confidence signals"
+        );
+
+        // Compute vendor/boot patch level staleness (YYYYMMDD format -> months delta)
+        let vendor_patch_level_stale = dev
+            .vendor_patch_level()
+            .map(|vpl| {
+                let now = DateTime::<Utc>::from(SystemTime::now());
+                let now_yyyymm = now.year_ce().1 * 100 + now.month();
+                let vpl_yyyymm = (vpl / 100) as u32; // YYYYMMDD -> YYYYMM
+                now_yyyymm.saturating_sub(vpl_yyyymm) > 18
+            })
+            .unwrap_or(false);
+
+        let boot_patch_level_stale = dev
+            .boot_patch_level()
+            .map(|bpl| {
+                let now = DateTime::<Utc>::from(SystemTime::now());
+                let now_yyyymm = now.year_ce().1 * 100 + now.month();
+                let bpl_yyyymm = (bpl / 100) as u32;
+                now_yyyymm.saturating_sub(bpl_yyyymm) > 18
+            })
+            .unwrap_or(false);
+
+        let os_patch_level_stale = os_patch_level_delta.map(|d| d > 12).unwrap_or(false);
+
+        tracing::info!(
+            os_version = ?dev.os_version(),
+            vendor_patch_level = ?dev.vendor_patch_level(),
+            boot_patch_level = ?dev.boot_patch_level(),
+            usage_count_limit = ?dev.usage_count_limit(),
+            algorithm = ?dev.algorithm(),
+            key_size = ?dev.key_size(),
+            ec_curve = ?dev.ec_curve(),
+            attestation_id_serial = ?attestation_id_serial,
+            attestation_id_imei = ?attestation_id_imei,
+            attestation_id_meid = ?attestation_id_meid,
+            attestation_id_second_imei = ?attestation_id_second_imei,
+            os_patch_level_stale = os_patch_level_stale,
+            vendor_patch_level_stale = vendor_patch_level_stale,
+            boot_patch_level_stale = boot_patch_level_stale,
+            "android verify: extended device metadata"
+        );
+
         let integrity_confidence = IntegrityConfidence {
             rkp_rooted,
             device_unique_attestation,
             has_id_attestation,
             unexpected_purpose,
+            unique_id_hex,
             verified_boot_key_hex,
             verified_boot_hash_hex,
             batch_cert_serial_hex,
             module_hash_hex,
             creation_time_delta_ms,
-            attestation_id_brand: to_utf8(dev.attestation_id_brand()),
-            attestation_id_manufacturer: to_utf8(dev.attestation_id_manufacturer()),
-            attestation_id_model: to_utf8(dev.attestation_id_model()),
+            attestation_id_brand,
+            attestation_id_device,
+            attestation_id_product,
+            attestation_id_serial,
+            attestation_id_imei,
+            attestation_id_meid,
+            attestation_id_manufacturer,
+            attestation_id_model,
+            attestation_id_second_imei,
+            os_version: dev.os_version(),
+            vendor_patch_level: dev.vendor_patch_level(),
+            boot_patch_level: dev.boot_patch_level(),
+            usage_count_limit: dev.usage_count_limit(),
+            algorithm: dev.algorithm(),
+            key_size: dev.key_size(),
+            ec_curve: dev.ec_curve(),
         };
 
         // Emit structured metrics for every signal so dashboards can track distribution.
@@ -332,29 +533,12 @@ impl AndroidAttestationService {
         )
         .increment(1);
 
-        if let Some(ref key_hex) = integrity_confidence.verified_boot_key_hex {
-            tracing::info!(
-                verified_boot_key = %key_hex,
-                rkp_rooted = rkp_rooted,
-                has_id_attestation = has_id_attestation,
-                device_unique = device_unique_attestation,
-                batch_serial = ?integrity_confidence.batch_cert_serial_hex,
-                "android attestation confidence signals"
-            );
-        }
-
-        let batch_cert_fingerprint = cert_chain
-            .intermediate_cert_der()
-            .map(|der| {
-                use super::keybox_defense::KeyboxDefense;
-                KeyboxDefense::fingerprint(der)
-            });
+        tracing::info!("android verify: verification complete, all checks passed");
 
         Ok(AndroidAttestationOutput {
             device_public_key: cert_chain.device_certificate().public_key(),
             os_patch_level_delta,
             integrity_confidence,
-            batch_cert_fingerprint,
         })
     }
 }

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -24,6 +24,9 @@ const KM_VERIFIED_BOOT_VERIFIED: u32 = 0;
 /// Android `KM_ORIGIN_GENERATED` — key generated inside secure `KeyMint` / Keymaster (TEE / `StrongBox`), not imported.
 const KM_ORIGIN_GENERATED: u64 = 0;
 
+/// Android `KM_PURPOSE_SIGN` — key purpose: signing.
+const KM_PURPOSE_SIGN: u64 = 2;
+
 #[derive(Debug, Error)]
 pub enum AndroidAttestationError {
     #[error("ca registry: {0}")]
@@ -84,9 +87,43 @@ pub enum AndroidAttestationError {
     BadCertificateDigestEncoding(#[source] DecodeError),
 }
 
+/// Signals extracted from the attestation chain that indicate how confident we
+/// are that the chain was produced by genuine, uncompromised hardware.
+/// None of these cause a hard rejection -- they are purely informational and
+/// emitted as metrics + structured logs so the caller can decide policy.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IntegrityConfidence {
+    /// Chain roots in a 2026 RKP-provisioned certificate (keybox bypass impossible).
+    pub rkp_rooted: bool,
+    /// StrongBox device-unique attestation key (tag 720); per-device, no batch key.
+    pub device_unique_attestation: bool,
+    /// True when at least brand + manufacturer + model are present in teeEnforced.
+    pub has_id_attestation: bool,
+    /// Set when purpose contains unexpected values (e.g. VERIFY in addition to SIGN).
+    pub unexpected_purpose: bool,
+    /// Hex-encoded verifiedBootKey from rootOfTrust (for allowlist checks / logging).
+    pub verified_boot_key_hex: Option<String>,
+    /// Hex-encoded verifiedBootHash.
+    pub verified_boot_hash_hex: Option<String>,
+    /// Batch (intermediate) certificate serial hex -- for cross-request anomaly tracking.
+    pub batch_cert_serial_hex: Option<String>,
+    /// Module hash hex (KeyMint v4+ / attestation v400+).
+    pub module_hash_hex: Option<String>,
+    /// creationDateTime delta in milliseconds (server_now - creation_date_time). Large
+    /// negative values or exact-zero deltas may indicate a forged timestamp.
+    pub creation_time_delta_ms: Option<i64>,
+    /// Device identity fields when present (UTF-8 best-effort).
+    pub attestation_id_brand: Option<String>,
+    pub attestation_id_manufacturer: Option<String>,
+    pub attestation_id_model: Option<String>,
+}
+
 pub struct AndroidAttestationOutput {
     pub device_public_key: Vec<u8>,
     pub os_patch_level_delta: Option<u32>,
+    pub integrity_confidence: IntegrityConfidence,
+    /// SHA-256 fingerprint of the intermediate (batch) cert DER for rate limiting.
+    pub batch_cert_fingerprint: Option<String>,
 }
 
 #[derive(Clone)]
@@ -231,9 +268,93 @@ impl AndroidAttestationService {
                     now - os_patch_level
                 });
 
+        let dev = cert_chain.device_certificate();
+
+        // --- Integrity confidence signals (informational, never blocking) ---
+
+        let rkp_rooted = self
+            .ca_registry
+            .is_rkp_root(&cert_chain.root_certificate().public_key);
+
+        let device_unique_attestation = dev.device_unique_attestation();
+
+        let has_id_attestation = dev.attestation_id_brand().is_some()
+            && dev.attestation_id_manufacturer().is_some()
+            && dev.attestation_id_model().is_some();
+
+        let expected_purpose: &[u64] = &[KM_PURPOSE_SIGN];
+        let unexpected_purpose = !dev.purpose().is_empty() && dev.purpose() != expected_purpose;
+
+        let verified_boot_key_hex = dev.verified_boot_key().map(hex::encode);
+        let verified_boot_hash_hex = dev.verified_boot_hash().map(hex::encode);
+
+        let batch_cert_serial_hex = cert_chain
+            .serials()
+            .get(1)
+            .map(|s| s.hex.clone());
+
+        let module_hash_hex = dev.module_hash().map(hex::encode);
+
+        let creation_time_delta_ms = dev.creation_date_time().map(|ct| {
+            let now_ms = SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64;
+            now_ms - ct as i64
+        });
+
+        let to_utf8 = |b: Option<&[u8]>| -> Option<String> {
+            b.and_then(|v| std::str::from_utf8(v).ok().map(String::from))
+        };
+
+        let integrity_confidence = IntegrityConfidence {
+            rkp_rooted,
+            device_unique_attestation,
+            has_id_attestation,
+            unexpected_purpose,
+            verified_boot_key_hex,
+            verified_boot_hash_hex,
+            batch_cert_serial_hex,
+            module_hash_hex,
+            creation_time_delta_ms,
+            attestation_id_brand: to_utf8(dev.attestation_id_brand()),
+            attestation_id_manufacturer: to_utf8(dev.attestation_id_manufacturer()),
+            attestation_id_model: to_utf8(dev.attestation_id_model()),
+        };
+
+        // Emit structured metrics for every signal so dashboards can track distribution.
+        metrics::counter!(
+            "attestation_gateway.confidence",
+            "rkp_rooted" => rkp_rooted.to_string(),
+            "device_unique" => device_unique_attestation.to_string(),
+            "has_id_attestation" => has_id_attestation.to_string(),
+            "unexpected_purpose" => unexpected_purpose.to_string(),
+        )
+        .increment(1);
+
+        if let Some(ref key_hex) = integrity_confidence.verified_boot_key_hex {
+            tracing::info!(
+                verified_boot_key = %key_hex,
+                rkp_rooted = rkp_rooted,
+                has_id_attestation = has_id_attestation,
+                device_unique = device_unique_attestation,
+                batch_serial = ?integrity_confidence.batch_cert_serial_hex,
+                "android attestation confidence signals"
+            );
+        }
+
+        let batch_cert_fingerprint = cert_chain
+            .intermediate_cert_der()
+            .map(|der| {
+                use super::keybox_defense::KeyboxDefense;
+                KeyboxDefense::fingerprint(der)
+            });
+
         Ok(AndroidAttestationOutput {
             device_public_key: cert_chain.device_certificate().public_key(),
             os_patch_level_delta,
+            integrity_confidence,
+            batch_cert_fingerprint,
         })
     }
 }

--- a/attestation-gateway/src/android/android_ca_registry.rs
+++ b/attestation-gateway/src/android/android_ca_registry.rs
@@ -20,6 +20,10 @@ pub enum AndroidCaRegistryError {
 #[derive(Debug, Clone)]
 pub struct AndroidCaRegistry {
     public_keys: Vec<Vec<u8>>,
+    /// Subset of `public_keys` belonging to roots that issue keys exclusively
+    /// through Remote Key Provisioning. Chains rooted here cannot have been
+    /// produced from a leaked legacy keybox.
+    rkp_public_keys: Vec<Vec<u8>>,
     /// DER-encoded trusted root certificates. Used to seed the OpenSSL X509
     /// trust store during chain verification so the trust anchor cannot be
     /// influenced by what the client sends.
@@ -28,20 +32,61 @@ pub struct AndroidCaRegistry {
 
 impl AndroidCaRegistry {
     pub fn from_default_pem() -> Result<Self, AndroidCaRegistryError> {
-        Self::from_pem(&[
-            include_bytes!("attestation_root_ca1.pem").to_vec(),
-            include_bytes!("attestation_root_ca2.pem").to_vec(),
-        ])
+        // ca1: Legacy RSA root (factory-provisioned keyboxes, vulnerable to leaks).
+        let legacy_pems = vec![include_bytes!("attestation_root_ca1.pem").to_vec()];
+
+        // ca2: Google "Key Attestation CA1" P-384 root (RKP-provisioned).
+        // Devices that went through Remote Key Provisioning chain to this root.
+        // Keybox bypass is impossible for chains rooted here because there is
+        // no factory-provisioned batch key -- keys are provisioned per-device.
+        let mut rkp_pems = vec![include_bytes!("attestation_root_ca2.pem").to_vec()];
+
+        if let Ok(extra) = std::fs::read("attestation_root_rkp_extra.pem") {
+            rkp_pems.push(extra);
+        }
+
+        Self::from_pem_with_rkp(&legacy_pems, &rkp_pems)
     }
 
-    pub fn from_pem(pem_certs: &[Vec<u8>]) -> Result<Self, AndroidCaRegistryError> {
-        let ca_certs = pem_certs
+    fn from_pem_with_rkp(
+        legacy_pems: &[Vec<u8>],
+        rkp_pems: &[Vec<u8>],
+    ) -> Result<Self, AndroidCaRegistryError> {
+        let all_pems: Vec<Vec<u8>> = legacy_pems.iter().chain(rkp_pems.iter()).cloned().collect();
+        let all_certs = all_pems
             .iter()
             .map(|pem| X509::from_pem(pem))
             .collect::<Result<Vec<X509>, openssl::error::ErrorStack>>()
             .map_err(|_| AndroidCaRegistryError::PemParsing)?;
 
-        Self::from_x509(&ca_certs)
+        let all_der = all_certs
+            .iter()
+            .map(|cert| cert.to_der())
+            .collect::<Result<Vec<Vec<u8>>, openssl::error::ErrorStack>>()
+            .map_err(|_| AndroidCaRegistryError::DerEncoding)?;
+
+        let all_public_keys = all_der
+            .iter()
+            .map(|der| {
+                let (_, cert) = X509Certificate::from_der(der)?;
+                Ok(Vec::from(cert.public_key().subject_public_key.data.clone()))
+            })
+            .collect::<Result<Vec<Vec<u8>>, X509Error>>()
+            .map_err(|_| AndroidCaRegistryError::DerParsing)?;
+
+        let rkp_count = rkp_pems.len();
+        let legacy_count = legacy_pems.len();
+        let rkp_public_keys = all_public_keys[legacy_count..legacy_count + rkp_count].to_vec();
+
+        Ok(Self {
+            public_keys: all_public_keys,
+            rkp_public_keys,
+            trusted_root_certs_der: all_der,
+        })
+    }
+
+    pub fn from_pem(pem_certs: &[Vec<u8>]) -> Result<Self, AndroidCaRegistryError> {
+        Self::from_pem_with_rkp(pem_certs, &[])
     }
 
     pub fn from_x509(x509_certs: &[X509]) -> Result<Self, AndroidCaRegistryError> {
@@ -66,6 +111,7 @@ impl AndroidCaRegistry {
 
         Ok(Self {
             public_keys: ca_public_keys,
+            rkp_public_keys: vec![],
             trusted_root_certs_der: der_certs.to_vec(),
         })
     }
@@ -73,6 +119,16 @@ impl AndroidCaRegistry {
     #[must_use]
     pub fn has_public_key(&self, public_key: &[u8]) -> bool {
         self.public_keys
+            .iter()
+            .any(|key| key.as_slice() == public_key)
+    }
+
+    /// Returns `true` when the root public key belongs to a Remote Key
+    /// Provisioning root, meaning the device went through RKP and the key
+    /// cannot have been produced from a leaked legacy keybox.
+    #[must_use]
+    pub fn is_rkp_root(&self, public_key: &[u8]) -> bool {
+        self.rkp_public_keys
             .iter()
             .any(|key| key.as_slice() == public_key)
     }

--- a/attestation-gateway/src/android/device_certificate.rs
+++ b/attestation-gateway/src/android/device_certificate.rs
@@ -98,6 +98,50 @@ impl DeviceCertificate {
     pub fn package_names(&self) -> &[String] {
         &self.key_description.package_names
     }
+
+    pub fn verified_boot_key(&self) -> Option<&[u8]> {
+        self.key_description.verified_boot_key.as_deref()
+    }
+
+    pub fn verified_boot_hash(&self) -> Option<&[u8]> {
+        self.key_description.verified_boot_hash.as_deref()
+    }
+
+    pub const fn device_unique_attestation(&self) -> bool {
+        self.key_description.device_unique_attestation
+    }
+
+    pub fn attestation_id_brand(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_brand.as_deref()
+    }
+
+    pub fn attestation_id_device(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_device.as_deref()
+    }
+
+    pub fn attestation_id_product(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_product.as_deref()
+    }
+
+    pub fn attestation_id_manufacturer(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_manufacturer.as_deref()
+    }
+
+    pub fn attestation_id_model(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_model.as_deref()
+    }
+
+    pub fn module_hash(&self) -> Option<&[u8]> {
+        self.key_description.module_hash.as_deref()
+    }
+
+    pub fn purpose(&self) -> &[u64] {
+        &self.key_description.purpose
+    }
+
+    pub const fn creation_date_time(&self) -> Option<u64> {
+        self.key_description.creation_date_time
+    }
 }
 
 impl DeviceCertificateError {

--- a/attestation-gateway/src/android/device_certificate.rs
+++ b/attestation-gateway/src/android/device_certificate.rs
@@ -99,6 +99,10 @@ impl DeviceCertificate {
         &self.key_description.package_names
     }
 
+    pub fn purpose(&self) -> &[u64] {
+        &self.key_description.purpose
+    }
+
     pub fn verified_boot_key(&self) -> Option<&[u8]> {
         self.key_description.verified_boot_key.as_deref()
     }
@@ -107,8 +111,12 @@ impl DeviceCertificate {
         self.key_description.verified_boot_hash.as_deref()
     }
 
-    pub const fn device_unique_attestation(&self) -> bool {
-        self.key_description.device_unique_attestation
+    pub const fn creation_date_time(&self) -> Option<u64> {
+        self.key_description.creation_date_time
+    }
+
+    pub fn unique_id(&self) -> Option<&[u8]> {
+        self.key_description.unique_id.as_deref()
     }
 
     pub fn attestation_id_brand(&self) -> Option<&[u8]> {
@@ -123,6 +131,18 @@ impl DeviceCertificate {
         self.key_description.attestation_id_product.as_deref()
     }
 
+    pub fn attestation_id_serial(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_serial.as_deref()
+    }
+
+    pub fn attestation_id_imei(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_imei.as_deref()
+    }
+
+    pub fn attestation_id_meid(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_meid.as_deref()
+    }
+
     pub fn attestation_id_manufacturer(&self) -> Option<&[u8]> {
         self.key_description.attestation_id_manufacturer.as_deref()
     }
@@ -131,16 +151,48 @@ impl DeviceCertificate {
         self.key_description.attestation_id_model.as_deref()
     }
 
+    pub fn attestation_id_second_imei(&self) -> Option<&[u8]> {
+        self.key_description.attestation_id_second_imei.as_deref()
+    }
+
+    pub const fn device_unique_attestation(&self) -> bool {
+        self.key_description.device_unique_attestation
+    }
+
     pub fn module_hash(&self) -> Option<&[u8]> {
         self.key_description.module_hash.as_deref()
     }
 
-    pub fn purpose(&self) -> &[u64] {
-        &self.key_description.purpose
+    pub const fn attestation_version(&self) -> u64 {
+        self.key_description.attestation_version
     }
 
-    pub const fn creation_date_time(&self) -> Option<u64> {
-        self.key_description.creation_date_time
+    pub const fn vendor_patch_level(&self) -> Option<u64> {
+        self.key_description.vendor_patch_level
+    }
+
+    pub const fn boot_patch_level(&self) -> Option<u64> {
+        self.key_description.boot_patch_level
+    }
+
+    pub const fn os_version(&self) -> Option<u64> {
+        self.key_description.os_version
+    }
+
+    pub const fn usage_count_limit(&self) -> Option<u64> {
+        self.key_description.usage_count_limit
+    }
+
+    pub const fn algorithm(&self) -> Option<u64> {
+        self.key_description.algorithm
+    }
+
+    pub const fn key_size(&self) -> Option<u64> {
+        self.key_description.key_size
+    }
+
+    pub const fn ec_curve(&self) -> Option<u64> {
+        self.key_description.ec_curve
     }
 }
 

--- a/attestation-gateway/src/android/key_description/key_description_1.rs
+++ b/attestation-gateway/src/android/key_description/key_description_1.rs
@@ -20,15 +20,15 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(5)]
     pub _digest: Option<UnorderedSetOfU64>,
     #[explicit(6)]
     pub _padding: Option<asn1::SetOf<'a, u64>>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(400)]
@@ -56,7 +56,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
 }

--- a/attestation-gateway/src/android/key_description/key_description_1.rs
+++ b/attestation-gateway/src/android/key_description/key_description_1.rs
@@ -10,7 +10,7 @@ pub struct KeyDescription1<'a> {
     pub _keymaster_version: u64,
     pub keymaster_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -18,7 +18,7 @@ pub struct KeyDescription1<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -48,7 +48,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(600)]
     pub _all_applications: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(703)]
@@ -64,7 +64,7 @@ pub struct AuthorizationList<'a> {
 /// Root of trust for attestation schema versions 1 and 2 (no `verified_boot_hash`).
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
 }

--- a/attestation-gateway/src/android/key_description/key_description_100.rs
+++ b/attestation-gateway/src/android/key_description/key_description_100.rs
@@ -10,7 +10,7 @@ pub struct KeyDescription100<'a> {
     pub _key_mint_version: u64,
     pub key_mint_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -29,7 +29,7 @@ impl<'a> KeyDescription100<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -59,7 +59,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(402)]
     pub _usage_expire_date_time: Option<u64>,
     #[explicit(405)]
-    pub _usage_count_limit: Option<u64>,
+    pub usage_count_limit: Option<u64>,
     #[explicit(502)]
     pub _user_secure_id: Option<u64>,
     #[explicit(503)]
@@ -77,7 +77,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(509)]
     pub _unlocked_device_req: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(704)]
@@ -89,27 +89,27 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
     #[explicit(718)]
-    pub _vendor_patch_level: Option<u64>,
+    pub vendor_patch_level: Option<u64>,
     #[explicit(719)]
-    pub _boot_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
     #[explicit(720)]
-    pub _device_unique_attestation: Option<asn1::Null>,
+    pub device_unique_attestation: Option<asn1::Null>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See
@@ -129,8 +129,8 @@ pub struct AttestationPackageInfo<'a> {
 
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
-    pub _verified_boot_hash: &'a [u8],
+    pub verified_boot_hash: &'a [u8],
 }

--- a/attestation-gateway/src/android/key_description/key_description_100.rs
+++ b/attestation-gateway/src/android/key_description/key_description_100.rs
@@ -31,9 +31,9 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(5)]
     pub _digest: Option<UnorderedSetOfU64>,
     #[explicit(6)]
@@ -43,7 +43,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(8)]
     pub _min_mac_length: Option<u64>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(203)]
@@ -83,7 +83,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/key_description_2.rs
+++ b/attestation-gateway/src/android/key_description/key_description_2.rs
@@ -11,7 +11,7 @@ pub struct KeyDescription2<'a> {
     pub _keymaster_version: u64,
     pub keymaster_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -30,7 +30,7 @@ impl<'a> KeyDescription2<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -60,7 +60,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(600)]
     pub _all_applications: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(703)]
@@ -74,21 +74,21 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See

--- a/attestation-gateway/src/android/key_description/key_description_2.rs
+++ b/attestation-gateway/src/android/key_description/key_description_2.rs
@@ -32,15 +32,15 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(5)]
     pub _digest: Option<UnorderedSetOfU64>,
     #[explicit(6)]
     pub _padding: Option<asn1::SetOf<'a, u64>>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(400)]
@@ -68,7 +68,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/key_description_200.rs
+++ b/attestation-gateway/src/android/key_description/key_description_200.rs
@@ -10,7 +10,7 @@ pub struct KeyDescription200<'a> {
     pub _key_mint_version: u64,
     pub key_mint_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -29,7 +29,7 @@ impl<'a> KeyDescription200<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -61,7 +61,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(402)]
     pub _usage_expire_date_time: Option<u64>,
     #[explicit(405)]
-    pub _usage_count_limit: Option<u64>,
+    pub usage_count_limit: Option<u64>,
     #[explicit(502)]
     pub _user_secure_id: Option<u64>,
     #[explicit(503)]
@@ -79,7 +79,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(509)]
     pub _unlocked_device_req: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(704)]
@@ -91,27 +91,27 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
     #[explicit(718)]
-    pub _vendor_patch_level: Option<u64>,
+    pub vendor_patch_level: Option<u64>,
     #[explicit(719)]
-    pub _boot_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
     #[explicit(720)]
-    pub _device_unique_attestation: Option<asn1::Null>,
+    pub device_unique_attestation: Option<asn1::Null>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See
@@ -131,8 +131,8 @@ pub struct AttestationPackageInfo<'a> {
 
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
-    pub _verified_boot_hash: &'a [u8],
+    pub verified_boot_hash: &'a [u8],
 }

--- a/attestation-gateway/src/android/key_description/key_description_200.rs
+++ b/attestation-gateway/src/android/key_description/key_description_200.rs
@@ -31,9 +31,9 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(4)]
     pub _block_mode: Option<asn1::SetOf<'a, u64>>,
     #[explicit(5)]
@@ -45,7 +45,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(8)]
     pub _min_mac_length: Option<u64>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(203)]
@@ -85,7 +85,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/key_description_3.rs
+++ b/attestation-gateway/src/android/key_description/key_description_3.rs
@@ -30,9 +30,9 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(4)]
     pub _block_mode: Option<asn1::SetOf<'a, u64>>,
     #[explicit(5)]
@@ -44,7 +44,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(8)]
     pub _min_mac_length: Option<u64>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(303)]
@@ -78,7 +78,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/key_description_3.rs
+++ b/attestation-gateway/src/android/key_description/key_description_3.rs
@@ -9,7 +9,7 @@ pub struct KeyDescription3<'a> {
     pub _keymaster_version: u64,
     pub keymaster_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -28,7 +28,7 @@ impl<'a> KeyDescription3<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -72,7 +72,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(509)]
     pub _unlocked_device_req: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(704)]
@@ -84,25 +84,25 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
     #[explicit(718)]
-    pub _vendor_patch_level: Option<u64>,
+    pub vendor_patch_level: Option<u64>,
     #[explicit(719)]
-    pub _boot_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See
@@ -122,8 +122,8 @@ pub struct AttestationPackageInfo<'a> {
 
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
-    pub _verified_boot_hash: &'a [u8],
+    pub verified_boot_hash: &'a [u8],
 }

--- a/attestation-gateway/src/android/key_description/key_description_300.rs
+++ b/attestation-gateway/src/android/key_description/key_description_300.rs
@@ -9,7 +9,7 @@ pub struct KeyDescription300<'a> {
     pub _key_mint_version: u64,
     pub key_mint_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -28,7 +28,7 @@ impl<'a> KeyDescription300<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -60,7 +60,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(402)]
     pub _usage_expire_date_time: Option<u64>,
     #[explicit(405)]
-    pub _usage_count_limit: Option<u64>,
+    pub usage_count_limit: Option<u64>,
     #[explicit(502)]
     pub _user_secure_id: Option<u64>,
     #[explicit(503)]
@@ -78,7 +78,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(509)]
     pub _unlocked_device_req: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(704)]
@@ -90,29 +90,29 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
     #[explicit(718)]
-    pub _vendor_patch_level: Option<u64>,
+    pub vendor_patch_level: Option<u64>,
     #[explicit(719)]
-    pub _boot_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
     #[explicit(720)]
-    pub _device_unique_attestation: Option<asn1::Null>,
+    pub device_unique_attestation: Option<asn1::Null>,
     #[explicit(723)]
-    pub _attestation_id_second_imei: Option<&'a [u8]>,
+    pub attestation_id_second_imei: Option<&'a [u8]>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See
@@ -132,8 +132,8 @@ pub struct AttestationPackageInfo<'a> {
 
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
-    pub _verified_boot_hash: &'a [u8],
+    pub verified_boot_hash: &'a [u8],
 }

--- a/attestation-gateway/src/android/key_description/key_description_300.rs
+++ b/attestation-gateway/src/android/key_description/key_description_300.rs
@@ -30,9 +30,9 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(4)]
     pub _block_mode: Option<asn1::SetOf<'a, u64>>,
     #[explicit(5)]
@@ -44,7 +44,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(8)]
     pub _min_mac_length: Option<u64>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(203)]
@@ -84,7 +84,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/key_description_4.rs
+++ b/attestation-gateway/src/android/key_description/key_description_4.rs
@@ -31,9 +31,9 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(4)]
     pub _block_mode: Option<asn1::SetOf<'a, u64>>,
     #[explicit(5)]
@@ -45,7 +45,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(8)]
     pub _min_mac_length: Option<u64>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(303)]
@@ -79,7 +79,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/key_description_4.rs
+++ b/attestation-gateway/src/android/key_description/key_description_4.rs
@@ -10,7 +10,7 @@ pub struct KeyDescription4<'a> {
     pub _keymaster_version: u64,
     pub keymaster_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -29,7 +29,7 @@ impl<'a> KeyDescription4<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -73,7 +73,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(509)]
     pub _unlocked_device_req: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(704)]
@@ -85,27 +85,27 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
     #[explicit(718)]
-    pub _vendor_patch_level: Option<u64>,
+    pub vendor_patch_level: Option<u64>,
     #[explicit(719)]
-    pub _boot_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
     #[explicit(720)]
-    pub _device_unique_attestation: Option<asn1::Null>,
+    pub device_unique_attestation: Option<asn1::Null>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See
@@ -125,8 +125,8 @@ pub struct AttestationPackageInfo<'a> {
 
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
-    pub _verified_boot_hash: &'a [u8],
+    pub verified_boot_hash: &'a [u8],
 }

--- a/attestation-gateway/src/android/key_description/key_description_400.rs
+++ b/attestation-gateway/src/android/key_description/key_description_400.rs
@@ -9,7 +9,7 @@ pub struct KeyDescription400<'a> {
     pub _key_mint_version: u64,
     pub key_mint_security_level: asn1::Enumerated,
     pub attestation_challenge: &'a [u8],
-    pub _unique_id: &'a [u8],
+    pub unique_id: &'a [u8],
     pub software_enforced: AuthorizationList<'a>,
     pub hardware_enforced: AuthorizationList<'a>,
 }
@@ -28,7 +28,7 @@ impl<'a> KeyDescription400<'a> {
 #[derive(asn1::Asn1Read)]
 pub struct AuthorizationList<'a> {
     #[explicit(1)]
-    pub _purpose: Option<asn1::SetOf<'a, u64>>,
+    pub purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
     pub algorithm: Option<u64>,
     #[explicit(3)]
@@ -60,7 +60,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(402)]
     pub _usage_expire_date_time: Option<u64>,
     #[explicit(405)]
-    pub _usage_count_limit: Option<u64>,
+    pub usage_count_limit: Option<u64>,
     #[explicit(502)]
     pub _user_secure_id: Option<u64>,
     #[explicit(503)]
@@ -78,7 +78,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(509)]
     pub _unlocked_device_req: Option<asn1::Null>,
     #[explicit(701)]
-    pub _creation_date_time: Option<u64>,
+    pub creation_date_time: Option<u64>,
     #[explicit(702)]
     pub origin: Option<u64>,
     #[explicit(704)]
@@ -90,31 +90,31 @@ pub struct AuthorizationList<'a> {
     #[explicit(709)]
     pub attestation_application_id: Option<&'a [u8]>,
     #[explicit(710)]
-    pub _attestation_id_brand: Option<&'a [u8]>,
+    pub attestation_id_brand: Option<&'a [u8]>,
     #[explicit(711)]
-    pub _attestation_id_device: Option<&'a [u8]>,
+    pub attestation_id_device: Option<&'a [u8]>,
     #[explicit(712)]
-    pub _attestation_id_product: Option<&'a [u8]>,
+    pub attestation_id_product: Option<&'a [u8]>,
     #[explicit(713)]
-    pub _attestation_id_serial: Option<&'a [u8]>,
+    pub attestation_id_serial: Option<&'a [u8]>,
     #[explicit(714)]
-    pub _attestation_id_imei: Option<&'a [u8]>,
+    pub attestation_id_imei: Option<&'a [u8]>,
     #[explicit(715)]
-    pub _attestation_id_meid: Option<&'a [u8]>,
+    pub attestation_id_meid: Option<&'a [u8]>,
     #[explicit(716)]
-    pub _attestation_id_manufacturer: Option<&'a [u8]>,
+    pub attestation_id_manufacturer: Option<&'a [u8]>,
     #[explicit(717)]
-    pub _attestation_id_model: Option<&'a [u8]>,
+    pub attestation_id_model: Option<&'a [u8]>,
     #[explicit(718)]
-    pub _vendor_patch_level: Option<u64>,
+    pub vendor_patch_level: Option<u64>,
     #[explicit(719)]
-    pub _boot_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
     #[explicit(720)]
-    pub _device_unique_attestation: Option<asn1::Null>,
+    pub device_unique_attestation: Option<asn1::Null>,
     #[explicit(723)]
-    pub _attestation_id_second_imei: Option<&'a [u8]>,
+    pub attestation_id_second_imei: Option<&'a [u8]>,
     #[explicit(724)]
-    pub _module_hash: Option<&'a [u8]>,
+    pub module_hash: Option<&'a [u8]>,
 }
 
 /// Contents of authorization tag `709` (`attestation_application_id`). See
@@ -134,8 +134,8 @@ pub struct AttestationPackageInfo<'a> {
 
 #[derive(asn1::Asn1Read, Debug)]
 pub struct RootOfTrust<'a> {
-    pub _verified_boot_key: &'a [u8],
+    pub verified_boot_key: &'a [u8],
     pub device_locked: bool,
     pub verified_boot_state: asn1::Enumerated,
-    pub _verified_boot_hash: &'a [u8],
+    pub verified_boot_hash: &'a [u8],
 }

--- a/attestation-gateway/src/android/key_description/key_description_400.rs
+++ b/attestation-gateway/src/android/key_description/key_description_400.rs
@@ -30,9 +30,9 @@ pub struct AuthorizationList<'a> {
     #[explicit(1)]
     pub _purpose: Option<asn1::SetOf<'a, u64>>,
     #[explicit(2)]
-    pub _algorithm: Option<u64>,
+    pub algorithm: Option<u64>,
     #[explicit(3)]
-    pub _key_size: Option<u64>,
+    pub key_size: Option<u64>,
     #[explicit(4)]
     pub _block_mode: Option<asn1::SetOf<'a, u64>>,
     #[explicit(5)]
@@ -44,7 +44,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(8)]
     pub _min_mac_length: Option<u64>,
     #[explicit(10)]
-    pub _ec_curve: Option<u64>,
+    pub ec_curve: Option<u64>,
     #[explicit(200)]
     pub _rsa_public_exponent: Option<u64>,
     #[explicit(203)]
@@ -84,7 +84,7 @@ pub struct AuthorizationList<'a> {
     #[explicit(704)]
     pub root_of_trust: Option<RootOfTrust<'a>>,
     #[explicit(705)]
-    pub _os_version: Option<u64>,
+    pub os_version: Option<u64>,
     #[explicit(706)]
     pub os_patch_level: Option<u32>,
     #[explicit(709)]

--- a/attestation-gateway/src/android/key_description/mod.rs
+++ b/attestation-gateway/src/android/key_description/mod.rs
@@ -36,10 +36,10 @@ fn unique_id_from_raw(raw: &[u8]) -> Option<Vec<u8>> {
 /// before this macro is invoked.
 macro_rules! extract_common_fields {
     ($hw:expr, $sw:expr) => {{
-        let os_version = $hw._os_version.or($sw._os_version);
-        let algorithm = $hw._algorithm.or($sw._algorithm);
-        let key_size = $hw._key_size.or($sw._key_size);
-        let ec_curve = $hw._ec_curve.or($sw._ec_curve);
+        let os_version = $hw.os_version.or($sw.os_version);
+        let algorithm = $hw.algorithm.or($sw.algorithm);
+        let key_size = $hw.key_size.or($sw.key_size);
+        let ec_curve = $hw.ec_curve.or($sw.ec_curve);
         (os_version, algorithm, key_size, ec_curve)
     }};
 }
@@ -338,21 +338,21 @@ impl KeyDescription {
             boot_patch_level: None,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: None,
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 
@@ -468,21 +468,21 @@ impl KeyDescription {
             boot_patch_level: key_description.hardware_enforced._boot_patch_level,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: None,
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 
@@ -601,21 +601,21 @@ impl KeyDescription {
             boot_patch_level: key_description.hardware_enforced._boot_patch_level,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: None,
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 
@@ -734,24 +734,24 @@ impl KeyDescription {
             boot_patch_level: key_description.hardware_enforced._boot_patch_level,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
                 ._usage_count_limit
                 .or(key_description.software_enforced._usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 
@@ -870,24 +870,24 @@ impl KeyDescription {
             boot_patch_level: key_description.hardware_enforced._boot_patch_level,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
                 ._usage_count_limit
                 .or(key_description.software_enforced._usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 
@@ -1009,24 +1009,24 @@ impl KeyDescription {
             boot_patch_level: key_description.hardware_enforced._boot_patch_level,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
                 ._usage_count_limit
                 .or(key_description.software_enforced._usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 
@@ -1151,24 +1151,24 @@ impl KeyDescription {
             boot_patch_level: key_description.hardware_enforced._boot_patch_level,
             os_version: key_description
                 .hardware_enforced
-                ._os_version
-                .or(key_description.software_enforced._os_version),
+                .os_version
+                .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
                 ._usage_count_limit
                 .or(key_description.software_enforced._usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
-                ._algorithm
-                .or(key_description.software_enforced._algorithm),
+                .algorithm
+                .or(key_description.software_enforced.algorithm),
             key_size: key_description
                 .hardware_enforced
-                ._key_size
-                .or(key_description.software_enforced._key_size),
+                .key_size
+                .or(key_description.software_enforced.key_size),
             ec_curve: key_description
                 .hardware_enforced
-                ._ec_curve
-                .or(key_description.software_enforced._ec_curve),
+                .ec_curve
+                .or(key_description.software_enforced.ec_curve),
         })
     }
 }

--- a/attestation-gateway/src/android/key_description/mod.rs
+++ b/attestation-gateway/src/android/key_description/mod.rs
@@ -175,7 +175,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -183,12 +183,12 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         let (os_version, algorithm, key_size, ec_curve) = extract_common_fields!(
             key_description.hardware_enforced,
@@ -196,7 +196,7 @@ impl KeyDescription {
         );
 
         Ok(Self {
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_challenge,
             attestation_security_level,
             key_mint_security_level,
@@ -268,7 +268,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -276,15 +276,15 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_challenge,
             attestation_security_level,
             key_mint_security_level,
@@ -301,35 +301,35 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: None,
             device_unique_attestation: false,
@@ -392,7 +392,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -400,18 +400,18 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let verified_boot_hash = key_description
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_hash.to_vec());
+            .map(|r| r.verified_boot_hash.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
             attestation_challenge,
@@ -423,7 +423,7 @@ impl KeyDescription {
             key_origin,
             package_names,
             attestation_signature_digests,
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_version: 3,
             purpose,
             verified_boot_key,
@@ -431,41 +431,41 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: None,
             device_unique_attestation: false,
             module_hash: None,
-            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
-            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            vendor_patch_level: key_description.hardware_enforced.vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced.boot_patch_level,
             os_version: key_description
                 .hardware_enforced
                 .os_version
@@ -522,7 +522,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -530,18 +530,18 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let verified_boot_hash = key_description
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_hash.to_vec());
+            .map(|r| r.verified_boot_hash.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
             attestation_challenge,
@@ -553,7 +553,7 @@ impl KeyDescription {
             key_origin,
             package_names,
             attestation_signature_digests,
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_version: 4,
             purpose,
             verified_boot_key,
@@ -561,44 +561,44 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: None,
             device_unique_attestation: key_description
                 .hardware_enforced
-                ._device_unique_attestation
+                .device_unique_attestation
                 .is_some(),
             module_hash: None,
-            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
-            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            vendor_patch_level: key_description.hardware_enforced.vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced.boot_patch_level,
             os_version: key_description
                 .hardware_enforced
                 .os_version
@@ -655,7 +655,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -663,18 +663,18 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let verified_boot_hash = key_description
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_hash.to_vec());
+            .map(|r| r.verified_boot_hash.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
             attestation_challenge,
@@ -686,7 +686,7 @@ impl KeyDescription {
             key_origin,
             package_names,
             attestation_signature_digests,
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_version: 100,
             purpose,
             verified_boot_key,
@@ -694,52 +694,52 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: None,
             device_unique_attestation: key_description
                 .hardware_enforced
-                ._device_unique_attestation
+                .device_unique_attestation
                 .is_some(),
             module_hash: None,
-            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
-            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            vendor_patch_level: key_description.hardware_enforced.vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced.boot_patch_level,
             os_version: key_description
                 .hardware_enforced
                 .os_version
                 .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
-                ._usage_count_limit
-                .or(key_description.software_enforced._usage_count_limit),
+                .usage_count_limit
+                .or(key_description.software_enforced.usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
                 .algorithm
@@ -791,7 +791,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -799,18 +799,18 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let verified_boot_hash = key_description
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_hash.to_vec());
+            .map(|r| r.verified_boot_hash.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
             attestation_challenge,
@@ -822,7 +822,7 @@ impl KeyDescription {
             key_origin,
             package_names,
             attestation_signature_digests,
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_version: 200,
             purpose,
             verified_boot_key,
@@ -830,52 +830,52 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: None,
             device_unique_attestation: key_description
                 .hardware_enforced
-                ._device_unique_attestation
+                .device_unique_attestation
                 .is_some(),
             module_hash: None,
-            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
-            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            vendor_patch_level: key_description.hardware_enforced.vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced.boot_patch_level,
             os_version: key_description
                 .hardware_enforced
                 .os_version
                 .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
-                ._usage_count_limit
-                .or(key_description.software_enforced._usage_count_limit),
+                .usage_count_limit
+                .or(key_description.software_enforced.usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
                 .algorithm
@@ -927,7 +927,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -935,18 +935,18 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let verified_boot_hash = key_description
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_hash.to_vec());
+            .map(|r| r.verified_boot_hash.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
             attestation_challenge,
@@ -958,7 +958,7 @@ impl KeyDescription {
             key_origin,
             package_names,
             attestation_signature_digests,
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_version: 300,
             purpose,
             verified_boot_key,
@@ -966,55 +966,55 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: key_description
                 .hardware_enforced
-                ._attestation_id_second_imei
+                .attestation_id_second_imei
                 .map(<[u8]>::to_vec),
             device_unique_attestation: key_description
                 .hardware_enforced
-                ._device_unique_attestation
+                .device_unique_attestation
                 .is_some(),
             module_hash: None,
-            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
-            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            vendor_patch_level: key_description.hardware_enforced.vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced.boot_patch_level,
             os_version: key_description
                 .hardware_enforced
                 .os_version
                 .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
-                ._usage_count_limit
-                .or(key_description.software_enforced._usage_count_limit),
+                .usage_count_limit
+                .or(key_description.software_enforced.usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
                 .algorithm
@@ -1066,7 +1066,7 @@ impl KeyDescription {
 
         let purpose = key_description
             .hardware_enforced
-            ._purpose
+            .purpose
             .map(|s| s.collect())
             .unwrap_or_default();
 
@@ -1074,18 +1074,18 @@ impl KeyDescription {
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_key.to_vec());
+            .map(|r| r.verified_boot_key.to_vec());
 
         let verified_boot_hash = key_description
             .hardware_enforced
             .root_of_trust
             .as_ref()
-            .map(|r| r._verified_boot_hash.to_vec());
+            .map(|r| r.verified_boot_hash.to_vec());
 
         let creation_date_time = key_description
             .hardware_enforced
-            ._creation_date_time
-            .or(key_description.software_enforced._creation_date_time);
+            .creation_date_time
+            .or(key_description.software_enforced.creation_date_time);
 
         Ok(Self {
             attestation_challenge,
@@ -1097,7 +1097,7 @@ impl KeyDescription {
             key_origin,
             package_names,
             attestation_signature_digests,
-            unique_id: unique_id_from_raw(key_description._unique_id),
+            unique_id: unique_id_from_raw(key_description.unique_id),
             attestation_version: 400,
             purpose,
             verified_boot_key,
@@ -1105,58 +1105,58 @@ impl KeyDescription {
             creation_date_time,
             attestation_id_brand: key_description
                 .hardware_enforced
-                ._attestation_id_brand
+                .attestation_id_brand
                 .map(<[u8]>::to_vec),
             attestation_id_device: key_description
                 .hardware_enforced
-                ._attestation_id_device
+                .attestation_id_device
                 .map(<[u8]>::to_vec),
             attestation_id_product: key_description
                 .hardware_enforced
-                ._attestation_id_product
+                .attestation_id_product
                 .map(<[u8]>::to_vec),
             attestation_id_serial: key_description
                 .hardware_enforced
-                ._attestation_id_serial
+                .attestation_id_serial
                 .map(<[u8]>::to_vec),
             attestation_id_imei: key_description
                 .hardware_enforced
-                ._attestation_id_imei
+                .attestation_id_imei
                 .map(<[u8]>::to_vec),
             attestation_id_meid: key_description
                 .hardware_enforced
-                ._attestation_id_meid
+                .attestation_id_meid
                 .map(<[u8]>::to_vec),
             attestation_id_manufacturer: key_description
                 .hardware_enforced
-                ._attestation_id_manufacturer
+                .attestation_id_manufacturer
                 .map(<[u8]>::to_vec),
             attestation_id_model: key_description
                 .hardware_enforced
-                ._attestation_id_model
+                .attestation_id_model
                 .map(<[u8]>::to_vec),
             attestation_id_second_imei: key_description
                 .hardware_enforced
-                ._attestation_id_second_imei
+                .attestation_id_second_imei
                 .map(<[u8]>::to_vec),
             device_unique_attestation: key_description
                 .hardware_enforced
-                ._device_unique_attestation
+                .device_unique_attestation
                 .is_some(),
             module_hash: key_description
                 .hardware_enforced
-                ._module_hash
+                .module_hash
                 .map(<[u8]>::to_vec),
-            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
-            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            vendor_patch_level: key_description.hardware_enforced.vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced.boot_patch_level,
             os_version: key_description
                 .hardware_enforced
                 .os_version
                 .or(key_description.software_enforced.os_version),
             usage_count_limit: key_description
                 .hardware_enforced
-                ._usage_count_limit
-                .or(key_description.software_enforced._usage_count_limit),
+                .usage_count_limit
+                .or(key_description.software_enforced.usage_count_limit),
             algorithm: key_description
                 .hardware_enforced
                 .algorithm

--- a/attestation-gateway/src/android/key_description/mod.rs
+++ b/attestation-gateway/src/android/key_description/mod.rs
@@ -21,6 +21,29 @@ use crate::android::key_description::key_description_200::KeyDescription200;
 use crate::android::key_description::key_description_300::KeyDescription300;
 use crate::android::key_description::key_description_400::KeyDescription400;
 
+/// Converts the raw `_unique_id` bytes into an `Option<Vec<u8>>` (None when empty).
+fn unique_id_from_raw(raw: &[u8]) -> Option<Vec<u8>> {
+    if raw.is_empty() {
+        None
+    } else {
+        Some(raw.to_vec())
+    }
+}
+
+/// Populates the common new fields from a parsed key description's hardware_enforced auth list.
+/// Use `$kd` for the parsed key description, `$hw` for `$kd.hardware_enforced`, and `$sw` for
+/// `$kd.software_enforced`. Fields not present in a given schema version should be set to None
+/// before this macro is invoked.
+macro_rules! extract_common_fields {
+    ($hw:expr, $sw:expr) => {{
+        let os_version = $hw._os_version.or($sw._os_version);
+        let algorithm = $hw._algorithm.or($sw._algorithm);
+        let key_size = $hw._key_size.or($sw._key_size);
+        let ec_curve = $hw._ec_curve.or($sw._ec_curve);
+        (os_version, algorithm, key_size, ec_curve)
+    }};
+}
+
 /// Reads the leading `attestation_version` INTEGER without parsing the rest of the SEQUENCE.
 ///
 /// `asn1::parse` / [`asn1::Sequence::parse`] require the entire SEQUENCE body to be consumed;
@@ -68,6 +91,7 @@ pub enum KeyDescriptionError {
 }
 
 pub struct KeyDescription {
+    pub unique_id: Option<Vec<u8>>,
     pub attestation_challenge: String,
     pub attestation_security_level: u32,
     pub key_mint_security_level: u32,
@@ -77,94 +101,29 @@ pub struct KeyDescription {
     pub key_origin: Option<u64>,
     pub package_names: Vec<String>,
     pub attestation_signature_digests: Option<Vec<Vec<u8>>>,
+    pub attestation_version: u64,
+    pub purpose: Vec<u64>,
     pub verified_boot_key: Option<Vec<u8>>,
     pub verified_boot_hash: Option<Vec<u8>>,
-    pub device_unique_attestation: bool,
+    pub creation_date_time: Option<u64>,
     pub attestation_id_brand: Option<Vec<u8>>,
     pub attestation_id_device: Option<Vec<u8>>,
     pub attestation_id_product: Option<Vec<u8>>,
+    pub attestation_id_serial: Option<Vec<u8>>,
+    pub attestation_id_imei: Option<Vec<u8>>,
+    pub attestation_id_meid: Option<Vec<u8>>,
     pub attestation_id_manufacturer: Option<Vec<u8>>,
     pub attestation_id_model: Option<Vec<u8>>,
+    pub attestation_id_second_imei: Option<Vec<u8>>,
+    pub device_unique_attestation: bool,
     pub module_hash: Option<Vec<u8>>,
-    pub purpose: Vec<u64>,
-    pub creation_date_time: Option<u64>,
-    pub batch_cert_serial_hex: Option<String>,
-}
-
-/// Default values for the new integrity-analysis fields, used by older attestation
-/// versions that do not carry these tags.
-impl KeyDescription {
-    fn integrity_defaults() -> IntegrityFieldDefaults {
-        IntegrityFieldDefaults {
-            verified_boot_key: None,
-            verified_boot_hash: None,
-            device_unique_attestation: false,
-            attestation_id_brand: None,
-            attestation_id_device: None,
-            attestation_id_product: None,
-            attestation_id_manufacturer: None,
-            attestation_id_model: None,
-            module_hash: None,
-            purpose: vec![],
-            creation_date_time: None,
-        }
-    }
-}
-
-struct IntegrityFieldDefaults {
-    verified_boot_key: Option<Vec<u8>>,
-    verified_boot_hash: Option<Vec<u8>>,
-    device_unique_attestation: bool,
-    attestation_id_brand: Option<Vec<u8>>,
-    attestation_id_device: Option<Vec<u8>>,
-    attestation_id_product: Option<Vec<u8>>,
-    attestation_id_manufacturer: Option<Vec<u8>>,
-    attestation_id_model: Option<Vec<u8>>,
-    module_hash: Option<Vec<u8>>,
-    purpose: Vec<u64>,
-    creation_date_time: Option<u64>,
-}
-
-macro_rules! extract_root_of_trust_fields {
-    ($hw:expr) => {{
-        let verified_boot_key = $hw.root_of_trust.as_ref().map(|r| r._verified_boot_key.to_vec());
-        let verified_boot_hash = $hw.root_of_trust.as_ref().map(|r| r._verified_boot_hash.to_vec());
-        (verified_boot_key, verified_boot_hash)
-    }};
-}
-
-macro_rules! extract_root_of_trust_fields_no_hash {
-    ($hw:expr) => {{
-        let verified_boot_key = $hw.root_of_trust.as_ref().map(|r| r._verified_boot_key.to_vec());
-        (verified_boot_key, None::<Vec<u8>>)
-    }};
-}
-
-macro_rules! extract_id_attestation {
-    ($hw:expr) => {{
-        let brand = $hw._attestation_id_brand.map(<[u8]>::to_vec);
-        let device = $hw._attestation_id_device.map(<[u8]>::to_vec);
-        let product = $hw._attestation_id_product.map(<[u8]>::to_vec);
-        let manufacturer = $hw._attestation_id_manufacturer.map(<[u8]>::to_vec);
-        let model = $hw._attestation_id_model.map(<[u8]>::to_vec);
-        (brand, device, product, manufacturer, model)
-    }};
-}
-
-macro_rules! extract_purpose {
-    ($hw:expr, $sw:expr) => {{
-        $hw._purpose
-            .as_ref()
-            .map(|s| s.clone().collect::<Vec<_>>())
-            .or_else(|| $sw._purpose.as_ref().map(|s| s.clone().collect::<Vec<_>>()))
-            .unwrap_or_default()
-    }};
-}
-
-macro_rules! extract_creation_date_time {
-    ($hw:expr, $sw:expr) => {
-        $hw._creation_date_time.or($sw._creation_date_time)
-    };
+    pub vendor_patch_level: Option<u64>,
+    pub boot_patch_level: Option<u64>,
+    pub os_version: Option<u64>,
+    pub usage_count_limit: Option<u64>,
+    pub algorithm: Option<u64>,
+    pub key_size: Option<u64>,
+    pub ec_curve: Option<u64>,
 }
 
 impl KeyDescription {
@@ -214,11 +173,30 @@ impl KeyDescription {
 
         let key_origin = key_description.hardware_enforced.origin;
 
-        let (verified_boot_key, verified_boot_hash) =
-            extract_root_of_trust_fields_no_hash!(key_description.hardware_enforced);
-        let defaults = Self::integrity_defaults();
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
+
+        let (os_version, algorithm, key_size, ec_curve) = extract_common_fields!(
+            key_description.hardware_enforced,
+            key_description.software_enforced
+        );
 
         Ok(Self {
+            unique_id: unique_id_from_raw(key_description._unique_id),
             attestation_challenge,
             attestation_security_level,
             key_mint_security_level,
@@ -228,248 +206,969 @@ impl KeyDescription {
             key_origin,
             package_names: vec![],
             attestation_signature_digests: None,
+            attestation_version: 1,
+            purpose,
             verified_boot_key,
-            verified_boot_hash,
-            device_unique_attestation: defaults.device_unique_attestation,
-            attestation_id_brand: defaults.attestation_id_brand,
-            attestation_id_device: defaults.attestation_id_device,
-            attestation_id_product: defaults.attestation_id_product,
-            attestation_id_manufacturer: defaults.attestation_id_manufacturer,
-            attestation_id_model: defaults.attestation_id_model,
-            module_hash: defaults.module_hash,
-            purpose: extract_purpose!(key_description.hardware_enforced, key_description.software_enforced),
-            creation_date_time: extract_creation_date_time!(key_description.hardware_enforced, key_description.software_enforced),
-            batch_cert_serial_hex: None,
+            verified_boot_hash: None,
+            creation_date_time,
+            attestation_id_brand: None,
+            attestation_id_device: None,
+            attestation_id_product: None,
+            attestation_id_serial: None,
+            attestation_id_imei: None,
+            attestation_id_meid: None,
+            attestation_id_manufacturer: None,
+            attestation_id_model: None,
+            attestation_id_second_imei: None,
+            device_unique_attestation: false,
+            module_hash: None,
+            vendor_patch_level: None,
+            boot_patch_level: None,
+            os_version,
+            usage_count_limit: None,
+            algorithm,
+            key_size,
+            ec_curve,
         })
     }
 
     fn from_key_description_2(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription2>(der)
+        let key_description = asn1::parse_single::<KeyDescription2>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.keymaster_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields_no_hash!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
+            unique_id: unique_id_from_raw(key_description._unique_id),
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.keymaster_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            attestation_version: 2,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash: None,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: None,
             device_unique_attestation: false,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model, module_hash: None,
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            module_hash: None,
+            vendor_patch_level: None,
+            boot_patch_level: None,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: None,
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 
     fn from_key_description_3(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription3>(der)
+        let key_description = asn1::parse_single::<KeyDescription3>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.keymaster_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let verified_boot_hash = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_hash.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.keymaster_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            unique_id: unique_id_from_raw(key_description._unique_id),
+            attestation_version: 3,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: None,
             device_unique_attestation: false,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model, module_hash: None,
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            module_hash: None,
+            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: None,
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 
     fn from_key_description_4(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription4>(der)
+        let key_description = asn1::parse_single::<KeyDescription4>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.keymaster_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
-        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let verified_boot_hash = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_hash.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.keymaster_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
-            device_unique_attestation: device_unique,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model, module_hash: None,
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            unique_id: unique_id_from_raw(key_description._unique_id),
+            attestation_version: 4,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: None,
+            device_unique_attestation: key_description
+                .hardware_enforced
+                ._device_unique_attestation
+                .is_some(),
+            module_hash: None,
+            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: None,
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 
     fn from_key_description_100(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription100>(der)
+        let key_description = asn1::parse_single::<KeyDescription100>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.key_mint_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
-        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let verified_boot_hash = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_hash.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.key_mint_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
-            device_unique_attestation: device_unique,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model, module_hash: None,
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            unique_id: unique_id_from_raw(key_description._unique_id),
+            attestation_version: 100,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: None,
+            device_unique_attestation: key_description
+                .hardware_enforced
+                ._device_unique_attestation
+                .is_some(),
+            module_hash: None,
+            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: key_description
+                .hardware_enforced
+                ._usage_count_limit
+                .or(key_description.software_enforced._usage_count_limit),
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 
     fn from_key_description_200(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription200>(der)
+        let key_description = asn1::parse_single::<KeyDescription200>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.key_mint_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
-        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let verified_boot_hash = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_hash.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.key_mint_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
-            device_unique_attestation: device_unique,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model, module_hash: None,
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            unique_id: unique_id_from_raw(key_description._unique_id),
+            attestation_version: 200,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: None,
+            device_unique_attestation: key_description
+                .hardware_enforced
+                ._device_unique_attestation
+                .is_some(),
+            module_hash: None,
+            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: key_description
+                .hardware_enforced
+                ._usage_count_limit
+                .or(key_description.software_enforced._usage_count_limit),
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 
     fn from_key_description_300(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription300>(der)
+        let key_description = asn1::parse_single::<KeyDescription300>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.key_mint_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
-        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let verified_boot_hash = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_hash.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.key_mint_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
-            device_unique_attestation: device_unique,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model, module_hash: None,
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            unique_id: unique_id_from_raw(key_description._unique_id),
+            attestation_version: 300,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: key_description
+                .hardware_enforced
+                ._attestation_id_second_imei
+                .map(<[u8]>::to_vec),
+            device_unique_attestation: key_description
+                .hardware_enforced
+                ._device_unique_attestation
+                .is_some(),
+            module_hash: None,
+            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: key_description
+                .hardware_enforced
+                ._usage_count_limit
+                .or(key_description.software_enforced._usage_count_limit),
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 
     fn from_key_description_400(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let kd = asn1::parse_single::<KeyDescription400>(der)
+        let key_description = asn1::parse_single::<KeyDescription400>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
-            .map_err(KeyDescriptionError::ParseChallenge)?;
-        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
-        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
-        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
-        let app_id = kd.try_parse_attestation_application_id();
+
+        let attestation_challenge =
+            String::from_utf8(key_description.attestation_challenge.to_vec())
+                .map_err(KeyDescriptionError::ParseChallenge)?;
+
+        let attestation_security_level = key_description.attestation_security_level.value();
+        let key_mint_security_level = key_description.key_mint_security_level.value();
+        let os_patch_level = key_description
+            .hardware_enforced
+            .os_patch_level
+            .or(key_description.software_enforced.os_patch_level);
+
+        let device_locked = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.device_locked);
+
+        let verified_boot_state = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r.verified_boot_state.value());
+
+        let key_origin = key_description.hardware_enforced.origin;
+
+        let app_id = key_description.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
-        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
-        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
-        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
+        let attestation_signature_digests =
+            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+
+        let purpose = key_description
+            .hardware_enforced
+            ._purpose
+            .map(|s| s.collect())
+            .unwrap_or_default();
+
+        let verified_boot_key = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_key.to_vec());
+
+        let verified_boot_hash = key_description
+            .hardware_enforced
+            .root_of_trust
+            .as_ref()
+            .map(|r| r._verified_boot_hash.to_vec());
+
+        let creation_date_time = key_description
+            .hardware_enforced
+            ._creation_date_time
+            .or(key_description.software_enforced._creation_date_time);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level: kd.attestation_security_level.value(),
-            key_mint_security_level: kd.key_mint_security_level.value(),
-            os_patch_level, device_locked, verified_boot_state,
-            key_origin: kd.hardware_enforced.origin,
-            package_names, attestation_signature_digests,
-            verified_boot_key, verified_boot_hash,
-            device_unique_attestation: device_unique,
-            attestation_id_brand: brand, attestation_id_device: device,
-            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
-            attestation_id_model: model,
-            module_hash: kd.hardware_enforced._module_hash.map(<[u8]>::to_vec),
-            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
-            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
-            batch_cert_serial_hex: None,
+            attestation_security_level,
+            key_mint_security_level,
+            os_patch_level,
+            device_locked,
+            verified_boot_state,
+            key_origin,
+            package_names,
+            attestation_signature_digests,
+            unique_id: unique_id_from_raw(key_description._unique_id),
+            attestation_version: 400,
+            purpose,
+            verified_boot_key,
+            verified_boot_hash,
+            creation_date_time,
+            attestation_id_brand: key_description
+                .hardware_enforced
+                ._attestation_id_brand
+                .map(<[u8]>::to_vec),
+            attestation_id_device: key_description
+                .hardware_enforced
+                ._attestation_id_device
+                .map(<[u8]>::to_vec),
+            attestation_id_product: key_description
+                .hardware_enforced
+                ._attestation_id_product
+                .map(<[u8]>::to_vec),
+            attestation_id_serial: key_description
+                .hardware_enforced
+                ._attestation_id_serial
+                .map(<[u8]>::to_vec),
+            attestation_id_imei: key_description
+                .hardware_enforced
+                ._attestation_id_imei
+                .map(<[u8]>::to_vec),
+            attestation_id_meid: key_description
+                .hardware_enforced
+                ._attestation_id_meid
+                .map(<[u8]>::to_vec),
+            attestation_id_manufacturer: key_description
+                .hardware_enforced
+                ._attestation_id_manufacturer
+                .map(<[u8]>::to_vec),
+            attestation_id_model: key_description
+                .hardware_enforced
+                ._attestation_id_model
+                .map(<[u8]>::to_vec),
+            attestation_id_second_imei: key_description
+                .hardware_enforced
+                ._attestation_id_second_imei
+                .map(<[u8]>::to_vec),
+            device_unique_attestation: key_description
+                .hardware_enforced
+                ._device_unique_attestation
+                .is_some(),
+            module_hash: key_description
+                .hardware_enforced
+                ._module_hash
+                .map(<[u8]>::to_vec),
+            vendor_patch_level: key_description.hardware_enforced._vendor_patch_level,
+            boot_patch_level: key_description.hardware_enforced._boot_patch_level,
+            os_version: key_description
+                .hardware_enforced
+                ._os_version
+                .or(key_description.software_enforced._os_version),
+            usage_count_limit: key_description
+                .hardware_enforced
+                ._usage_count_limit
+                .or(key_description.software_enforced._usage_count_limit),
+            algorithm: key_description
+                .hardware_enforced
+                ._algorithm
+                .or(key_description.software_enforced._algorithm),
+            key_size: key_description
+                .hardware_enforced
+                ._key_size
+                .or(key_description.software_enforced._key_size),
+            ec_curve: key_description
+                .hardware_enforced
+                ._ec_curve
+                .or(key_description.software_enforced._ec_curve),
         })
     }
 }

--- a/attestation-gateway/src/android/key_description/mod.rs
+++ b/attestation-gateway/src/android/key_description/mod.rs
@@ -77,6 +77,94 @@ pub struct KeyDescription {
     pub key_origin: Option<u64>,
     pub package_names: Vec<String>,
     pub attestation_signature_digests: Option<Vec<Vec<u8>>>,
+    pub verified_boot_key: Option<Vec<u8>>,
+    pub verified_boot_hash: Option<Vec<u8>>,
+    pub device_unique_attestation: bool,
+    pub attestation_id_brand: Option<Vec<u8>>,
+    pub attestation_id_device: Option<Vec<u8>>,
+    pub attestation_id_product: Option<Vec<u8>>,
+    pub attestation_id_manufacturer: Option<Vec<u8>>,
+    pub attestation_id_model: Option<Vec<u8>>,
+    pub module_hash: Option<Vec<u8>>,
+    pub purpose: Vec<u64>,
+    pub creation_date_time: Option<u64>,
+    pub batch_cert_serial_hex: Option<String>,
+}
+
+/// Default values for the new integrity-analysis fields, used by older attestation
+/// versions that do not carry these tags.
+impl KeyDescription {
+    fn integrity_defaults() -> IntegrityFieldDefaults {
+        IntegrityFieldDefaults {
+            verified_boot_key: None,
+            verified_boot_hash: None,
+            device_unique_attestation: false,
+            attestation_id_brand: None,
+            attestation_id_device: None,
+            attestation_id_product: None,
+            attestation_id_manufacturer: None,
+            attestation_id_model: None,
+            module_hash: None,
+            purpose: vec![],
+            creation_date_time: None,
+        }
+    }
+}
+
+struct IntegrityFieldDefaults {
+    verified_boot_key: Option<Vec<u8>>,
+    verified_boot_hash: Option<Vec<u8>>,
+    device_unique_attestation: bool,
+    attestation_id_brand: Option<Vec<u8>>,
+    attestation_id_device: Option<Vec<u8>>,
+    attestation_id_product: Option<Vec<u8>>,
+    attestation_id_manufacturer: Option<Vec<u8>>,
+    attestation_id_model: Option<Vec<u8>>,
+    module_hash: Option<Vec<u8>>,
+    purpose: Vec<u64>,
+    creation_date_time: Option<u64>,
+}
+
+macro_rules! extract_root_of_trust_fields {
+    ($hw:expr) => {{
+        let verified_boot_key = $hw.root_of_trust.as_ref().map(|r| r._verified_boot_key.to_vec());
+        let verified_boot_hash = $hw.root_of_trust.as_ref().map(|r| r._verified_boot_hash.to_vec());
+        (verified_boot_key, verified_boot_hash)
+    }};
+}
+
+macro_rules! extract_root_of_trust_fields_no_hash {
+    ($hw:expr) => {{
+        let verified_boot_key = $hw.root_of_trust.as_ref().map(|r| r._verified_boot_key.to_vec());
+        (verified_boot_key, None::<Vec<u8>>)
+    }};
+}
+
+macro_rules! extract_id_attestation {
+    ($hw:expr) => {{
+        let brand = $hw._attestation_id_brand.map(<[u8]>::to_vec);
+        let device = $hw._attestation_id_device.map(<[u8]>::to_vec);
+        let product = $hw._attestation_id_product.map(<[u8]>::to_vec);
+        let manufacturer = $hw._attestation_id_manufacturer.map(<[u8]>::to_vec);
+        let model = $hw._attestation_id_model.map(<[u8]>::to_vec);
+        (brand, device, product, manufacturer, model)
+    }};
+}
+
+macro_rules! extract_purpose {
+    ($hw:expr, $sw:expr) => {{
+        $hw._purpose
+            .as_ref()
+            .map(|s| s.clone().collect::<Vec<_>>())
+            .or_else(|| $sw._purpose.as_ref().map(|s| s.clone().collect::<Vec<_>>()))
+            .unwrap_or_default()
+    }};
+}
+
+macro_rules! extract_creation_date_time {
+    ($hw:expr, $sw:expr) => {
+        $hw._creation_date_time.or($sw._creation_date_time)
+    };
 }
 
 impl KeyDescription {
@@ -126,6 +214,10 @@ impl KeyDescription {
 
         let key_origin = key_description.hardware_enforced.origin;
 
+        let (verified_boot_key, verified_boot_hash) =
+            extract_root_of_trust_fields_no_hash!(key_description.hardware_enforced);
+        let defaults = Self::integrity_defaults();
+
         Ok(Self {
             attestation_challenge,
             attestation_security_level,
@@ -136,335 +228,248 @@ impl KeyDescription {
             key_origin,
             package_names: vec![],
             attestation_signature_digests: None,
+            verified_boot_key,
+            verified_boot_hash,
+            device_unique_attestation: defaults.device_unique_attestation,
+            attestation_id_brand: defaults.attestation_id_brand,
+            attestation_id_device: defaults.attestation_id_device,
+            attestation_id_product: defaults.attestation_id_product,
+            attestation_id_manufacturer: defaults.attestation_id_manufacturer,
+            attestation_id_model: defaults.attestation_id_model,
+            module_hash: defaults.module_hash,
+            purpose: extract_purpose!(key_description.hardware_enforced, key_description.software_enforced),
+            creation_date_time: extract_creation_date_time!(key_description.hardware_enforced, key_description.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_2(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription2>(der)
+        let kd = asn1::parse_single::<KeyDescription2>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.keymaster_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields_no_hash!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.keymaster_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: false,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model, module_hash: None,
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_3(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription3>(der)
+        let kd = asn1::parse_single::<KeyDescription3>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.keymaster_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.keymaster_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: false,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model, module_hash: None,
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_4(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription4>(der)
+        let kd = asn1::parse_single::<KeyDescription4>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.keymaster_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.keymaster_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: device_unique,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model, module_hash: None,
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_100(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription100>(der)
+        let kd = asn1::parse_single::<KeyDescription100>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.key_mint_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.key_mint_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: device_unique,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model, module_hash: None,
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_200(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription200>(der)
+        let kd = asn1::parse_single::<KeyDescription200>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.key_mint_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.key_mint_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: device_unique,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model, module_hash: None,
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_300(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription300>(der)
+        let kd = asn1::parse_single::<KeyDescription300>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.key_mint_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.key_mint_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: device_unique,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model, module_hash: None,
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 
     fn from_key_description_400(der: &[u8]) -> Result<Self, KeyDescriptionError> {
-        let key_description = asn1::parse_single::<KeyDescription400>(der)
+        let kd = asn1::parse_single::<KeyDescription400>(der)
             .map_err(|e| KeyDescriptionError::Parsing(Box::new(e)))?;
-
-        let attestation_challenge =
-            String::from_utf8(key_description.attestation_challenge.to_vec())
-                .map_err(KeyDescriptionError::ParseChallenge)?;
-
-        let attestation_security_level = key_description.attestation_security_level.value();
-        let key_mint_security_level = key_description.key_mint_security_level.value();
-        let os_patch_level = key_description
-            .hardware_enforced
-            .os_patch_level
-            .or(key_description.software_enforced.os_patch_level);
-
-        let device_locked = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.device_locked);
-
-        let verified_boot_state = key_description
-            .hardware_enforced
-            .root_of_trust
-            .as_ref()
-            .map(|r| r.verified_boot_state.value());
-
-        let key_origin = key_description.hardware_enforced.origin;
-
-        let app_id = key_description.try_parse_attestation_application_id();
+        let attestation_challenge = String::from_utf8(kd.attestation_challenge.to_vec())
+            .map_err(KeyDescriptionError::ParseChallenge)?;
+        let os_patch_level = kd.hardware_enforced.os_patch_level.or(kd.software_enforced.os_patch_level);
+        let device_locked = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.device_locked);
+        let verified_boot_state = kd.hardware_enforced.root_of_trust.as_ref().map(|r| r.verified_boot_state.value());
+        let app_id = kd.try_parse_attestation_application_id();
         let package_names = package_names_from_app_id!(app_id);
-        let attestation_signature_digests =
-            app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let attestation_signature_digests = app_id.map(|aid| aid.signature_digests.map(<[u8]>::to_vec).collect());
+        let (verified_boot_key, verified_boot_hash) = extract_root_of_trust_fields!(kd.hardware_enforced);
+        let (brand, device, product, manufacturer, model) = extract_id_attestation!(kd.hardware_enforced);
+        let device_unique = kd.hardware_enforced._device_unique_attestation.is_some();
 
         Ok(Self {
             attestation_challenge,
-            attestation_security_level,
-            key_mint_security_level,
-            os_patch_level,
-            device_locked,
-            verified_boot_state,
-            key_origin,
-            package_names,
-            attestation_signature_digests,
+            attestation_security_level: kd.attestation_security_level.value(),
+            key_mint_security_level: kd.key_mint_security_level.value(),
+            os_patch_level, device_locked, verified_boot_state,
+            key_origin: kd.hardware_enforced.origin,
+            package_names, attestation_signature_digests,
+            verified_boot_key, verified_boot_hash,
+            device_unique_attestation: device_unique,
+            attestation_id_brand: brand, attestation_id_device: device,
+            attestation_id_product: product, attestation_id_manufacturer: manufacturer,
+            attestation_id_model: model,
+            module_hash: kd.hardware_enforced._module_hash.map(<[u8]>::to_vec),
+            purpose: extract_purpose!(kd.hardware_enforced, kd.software_enforced),
+            creation_date_time: extract_creation_date_time!(kd.hardware_enforced, kd.software_enforced),
+            batch_cert_serial_hex: None,
         })
     }
 }

--- a/attestation-gateway/src/android/mod.rs
+++ b/attestation-gateway/src/android/mod.rs
@@ -4,13 +4,14 @@ pub use integrity_token_data::PlayIntegrityToken;
 use josekit::jwe::{self, A256KW};
 use josekit::jws::ES256;
 
-mod android_attestation_service;
+pub mod android_attestation_service;
 mod android_ca_registry;
 mod android_cert_chain;
 mod android_revocation_list;
 mod device_certificate;
 mod integrity_token_data;
-mod key_description;
+pub mod key_description;
+pub mod keybox_defense;
 mod root_certificate;
 
 pub use android_attestation_service::AndroidAttestationService;

--- a/attestation-gateway/src/android/mod.rs
+++ b/attestation-gateway/src/android/mod.rs
@@ -11,7 +11,6 @@ mod android_revocation_list;
 mod device_certificate;
 mod integrity_token_data;
 pub mod key_description;
-pub mod keybox_defense;
 mod root_certificate;
 
 pub use android_attestation_service::AndroidAttestationService;

--- a/attestation-gateway/src/main.rs
+++ b/attestation-gateway/src/main.rs
@@ -7,6 +7,7 @@ use metrics_exporter_statsd::StatsdBuilder;
 use redis::aio::ConnectionManager;
 use regex::Regex;
 use std::{env, fmt};
+use tracing_subscriber::EnvFilter;
 
 mod android;
 mod apple;
@@ -26,6 +27,9 @@ async fn main() {
         .json()
         .with_target(false)
         .flatten_event(true)
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .init();
 
     tracing::info!("Starting attestation gateway...");

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -17,7 +17,7 @@ use redis::aio::ConnectionManager;
 use schemars::JsonSchema;
 
 use crate::{
-    android::{AndroidAttestationService, android_attestation_service::IntegrityConfidence},
+    android::AndroidAttestationService,
     apple, keys, kms_jws,
     nonces::{NonceDb, NonceDbError},
     utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
@@ -57,7 +57,6 @@ pub struct IntegrityTokenPayload {
     pub cnf: Vec<u8>,
     pub pass: bool,
     pub exp: i64,
-    pub integrity_confidence: Option<IntegrityConfidence>,
 }
 
 impl IntegrityTokenPayload {
@@ -107,12 +106,6 @@ impl IntegrityTokenPayload {
         payload.set_claim("aud", Some(josekit::Value::String(self.aud.clone())))?;
         payload.set_claim("cnf", Some(josekit::Value::Object(cfn)))?;
         payload.set_claim("pass", Some(josekit::Value::Bool(self.pass)))?;
-
-        if let Some(ref ic) = self.integrity_confidence {
-            let ic_json = serde_json::to_value(ic)
-                .map_err(|e| eyre::eyre!("failed to serialize integrity_confidence: {e}"))?;
-            payload.set_claim("integrity_confidence", Some(ic_json))?;
-        }
 
         Ok(payload)
     }
@@ -165,8 +158,6 @@ pub async fn handler(
 
     let challenge = format!("n={},av={}", request.nonce, request.app_version);
     let platform = request.bundle_identifier.platform();
-
-    let mut android_confidence: Option<IntegrityConfidence> = None;
 
     let device_public_key = match platform {
         Platform::AppleIOS => {
@@ -252,7 +243,6 @@ pub async fn handler(
                 }
             }
 
-            android_confidence = Some(attestation_output.integrity_confidence);
             attestation_output.device_public_key
         }
     };
@@ -318,7 +308,6 @@ pub async fn handler(
             cnf: device_public_key,
             pass: true,
             exp,
-            integrity_confidence: android_confidence,
         },
     )
     .await?;

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -17,11 +17,7 @@ use redis::aio::ConnectionManager;
 use schemars::JsonSchema;
 
 use crate::{
-    android::{
-        AndroidAttestationService,
-        android_attestation_service::IntegrityConfidence,
-        keybox_defense::{KeyboxDefense, RiskLevel},
-    },
+    android::{AndroidAttestationService, android_attestation_service::IntegrityConfidence},
     apple, keys, kms_jws,
     nonces::{NonceDb, NonceDbError},
     utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
@@ -35,6 +31,16 @@ pub struct Request {
     pub bundle_identifier: BundleIdentifier,
     pub apple_attestation: Option<String>,
     pub android_attestation: Option<Vec<String>>,
+    #[serde(default)]
+    pub security_level: Option<String>,
+    #[serde(default)]
+    pub os_api_level: Option<u32>,
+    #[serde(default)]
+    pub device_properties_included: Option<bool>,
+    #[serde(default)]
+    pub integrity_signature: Option<String>,
+    #[serde(default)]
+    pub device_key_expires_at: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
@@ -120,18 +126,42 @@ pub async fn handler(
     Extension(aws_config): Extension<SdkConfig>,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
-    let tracing_span = tracing::span!(tracing::Level::DEBUG, "a", endpoint = "/a");
+    let tracing_span = tracing::span!(tracing::Level::INFO, "a", endpoint = "/a");
     let _enter = tracing_span.enter();
+
+    tracing::info!(
+        nonce = %request.nonce,
+        app_version = %request.app_version,
+        bundle_identifier = %request.bundle_identifier,
+        has_apple_attestation = request.apple_attestation.is_some(),
+        has_android_attestation = request.android_attestation.is_some(),
+        android_cert_chain_len = request.android_attestation.as_ref().map_or(0, |v| v.len()),
+        security_level = ?request.security_level,
+        os_api_level = ?request.os_api_level,
+        device_properties_included = ?request.device_properties_included,
+        has_integrity_signature = request.integrity_signature.is_some(),
+        device_key_expires_at = ?request.device_key_expires_at,
+        "/a handler: incoming request"
+    );
 
     if !global_config
         .enabled_bundle_identifiers
         .contains(&request.bundle_identifier)
     {
+        tracing::info!(
+            bundle_identifier = %request.bundle_identifier,
+            "/a handler: bundle identifier not enabled, rejecting"
+        );
         return Err(RequestError {
             code: ErrorCode::BadRequest,
             details: Some("This bundle identifier is currently unavailable.".to_string()),
         });
     }
+
+    tracing::info!(
+        bundle_identifier = %request.bundle_identifier,
+        "/a handler: bundle identifier check passed"
+    );
 
     let challenge = format!("n={},av={}", request.nonce, request.app_version);
     let platform = request.bundle_identifier.platform();
@@ -158,6 +188,12 @@ pub async fn handler(
                 details: Some("Android attestation is required".to_string()),
             })?;
 
+            tracing::info!(
+                cert_chain_len = android_cert_chain.len(),
+                bundle_identifier = %request.bundle_identifier,
+                "/a handler: starting Android attestation verify"
+            );
+
             let attestation_result = android_attestation.verify(
                 &android_cert_chain,
                 &request.nonce,
@@ -166,7 +202,16 @@ pub async fn handler(
             );
 
             let attestation_output = match attestation_result {
-                Ok(attestation_output) => Ok(attestation_output),
+                Ok(output) => {
+                    tracing::info!(
+                        os_patch_level_delta = ?output.os_patch_level_delta,
+                        rkp_rooted = output.integrity_confidence.rkp_rooted,
+                        device_unique = output.integrity_confidence.device_unique_attestation,
+                        has_id_attestation = output.integrity_confidence.has_id_attestation,
+                        "/a handler: Android attestation verify succeeded"
+                    );
+                    Ok(output)
+                }
                 Err(e) => {
                     metrics::counter!("attestation_gateway.android_error",  "reason" => e.reason_tag())
                         .increment(1);
@@ -179,7 +224,7 @@ pub async fn handler(
                             details: None,
                         })
                     } else {
-                        tracing::debug!(error = ?e, "Error validating Android attestation");
+                        tracing::warn!(error = ?e, "/a handler: Android attestation client error");
 
                         Err(RequestError {
                             code: ErrorCode::BadRequest,
@@ -195,37 +240,6 @@ pub async fn handler(
             } else {
                 metrics::counter!("attestation_gateway.android_missing_os_patch_level")
                     .increment(1);
-            }
-
-            // --- Keybox defense: rate limiting + blocklist ---
-            if let Some(ref fp) = attestation_output.batch_cert_fingerprint {
-                let keybox_defense = KeyboxDefense::new(
-                    crate::android::keybox_defense::KeyboxDefenseConfig::from_env(),
-                );
-                match keybox_defense.evaluate(&mut redis, fp).await {
-                    Ok(verdict) => {
-                        if verdict.risk_level == RiskLevel::Blocked {
-                            return Err(RequestError {
-                                code: ErrorCode::BadRequest,
-                                details: Some("certificate blocklisted".to_string()),
-                            });
-                        }
-                        if verdict.risk_level == RiskLevel::High {
-                            tracing::warn!(
-                                fingerprint = %fp,
-                                count = verdict.request_count,
-                                "batch cert exceeds block threshold -- rejecting"
-                            );
-                            return Err(RequestError {
-                                code: ErrorCode::BadRequest,
-                                details: Some("rate limit exceeded for attestation certificate".to_string()),
-                            });
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(error = ?e, "keybox defense evaluation failed (non-blocking)");
-                    }
-                }
             }
 
             // --- osPatchLevel: log-only signal ---
@@ -246,6 +260,11 @@ pub async fn handler(
     metrics::counter!("attestation_gateway.attestation", "platform" => platform.to_string())
         .increment(1);
 
+    tracing::info!(
+        nonce = %request.nonce,
+        "/a handler: consuming nonce"
+    );
+
     let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
         if matches!(e, NonceDbError::NonceNotFound) {
             RequestError {
@@ -262,6 +281,12 @@ pub async fn handler(
         }
     })?;
 
+    tracing::info!(
+        aud = %token_details.aud,
+        exp_max = token_details.exp_max,
+        "/a handler: nonce consumed successfully"
+    );
+
     let exp = match request.exp {
         Some(exp) => {
             if exp > token_details.exp_max {
@@ -275,6 +300,12 @@ pub async fn handler(
         }
         None => Ok(token_details.exp_max),
     }?;
+
+    tracing::info!(
+        exp = exp,
+        platform = %platform,
+        "/a handler: generating integrity token"
+    );
 
     let integrity_token = generate_integrity_token(
         &mut redis,
@@ -291,6 +322,8 @@ pub async fn handler(
         },
     )
     .await?;
+
+    tracing::info!("/a handler: integrity token generated successfully");
 
     Ok(Json(Response { integrity_token }))
 }

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -17,7 +17,11 @@ use redis::aio::ConnectionManager;
 use schemars::JsonSchema;
 
 use crate::{
-    android::AndroidAttestationService,
+    android::{
+        AndroidAttestationService,
+        android_attestation_service::IntegrityConfidence,
+        keybox_defense::{KeyboxDefense, RiskLevel},
+    },
     apple, keys, kms_jws,
     nonces::{NonceDb, NonceDbError},
     utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
@@ -47,6 +51,7 @@ pub struct IntegrityTokenPayload {
     pub cnf: Vec<u8>,
     pub pass: bool,
     pub exp: i64,
+    pub integrity_confidence: Option<IntegrityConfidence>,
 }
 
 impl IntegrityTokenPayload {
@@ -97,6 +102,12 @@ impl IntegrityTokenPayload {
         payload.set_claim("cnf", Some(josekit::Value::Object(cfn)))?;
         payload.set_claim("pass", Some(josekit::Value::Bool(self.pass)))?;
 
+        if let Some(ref ic) = self.integrity_confidence {
+            let ic_json = serde_json::to_value(ic)
+                .map_err(|e| eyre::eyre!("failed to serialize integrity_confidence: {e}"))?;
+            payload.set_claim("integrity_confidence", Some(ic_json))?;
+        }
+
         Ok(payload)
     }
 }
@@ -124,6 +135,8 @@ pub async fn handler(
 
     let challenge = format!("n={},av={}", request.nonce, request.app_version);
     let platform = request.bundle_identifier.platform();
+
+    let mut android_confidence: Option<IntegrityConfidence> = None;
 
     let device_public_key = match platform {
         Platform::AppleIOS => {
@@ -184,6 +197,48 @@ pub async fn handler(
                     .increment(1);
             }
 
+            // --- Keybox defense: rate limiting + blocklist ---
+            if let Some(ref fp) = attestation_output.batch_cert_fingerprint {
+                let keybox_defense = KeyboxDefense::new(
+                    crate::android::keybox_defense::KeyboxDefenseConfig::from_env(),
+                );
+                match keybox_defense.evaluate(&mut redis, fp).await {
+                    Ok(verdict) => {
+                        if verdict.risk_level == RiskLevel::Blocked {
+                            return Err(RequestError {
+                                code: ErrorCode::BadRequest,
+                                details: Some("certificate blocklisted".to_string()),
+                            });
+                        }
+                        if verdict.risk_level == RiskLevel::High {
+                            tracing::warn!(
+                                fingerprint = %fp,
+                                count = verdict.request_count,
+                                "batch cert exceeds block threshold -- rejecting"
+                            );
+                            return Err(RequestError {
+                                code: ErrorCode::BadRequest,
+                                details: Some("rate limit exceeded for attestation certificate".to_string()),
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(error = ?e, "keybox defense evaluation failed (non-blocking)");
+                    }
+                }
+            }
+
+            // --- osPatchLevel: log-only signal ---
+            if let Some(delta) = attestation_output.os_patch_level_delta {
+                if delta > 6 {
+                    tracing::warn!(
+                        os_patch_level_delta = delta,
+                        "device os patch level is stale"
+                    );
+                }
+            }
+
+            android_confidence = Some(attestation_output.integrity_confidence);
             attestation_output.device_public_key
         }
     };
@@ -232,6 +287,7 @@ pub async fn handler(
             cnf: device_public_key,
             pass: true,
             exp,
+            integrity_confidence: android_confidence,
         },
     )
     .await?;

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -187,6 +187,20 @@ impl BundleIdentifier {
         }
     }
 
+    /// Optional alternate signing-certificate digest accepted only when the
+    /// gateway runs with `ATTESTATION_GATEWAY_ACCEPT_ALT_SIGNING_CERT=1`.
+    /// Lets debug/test builds of the World App attest against the **staging**
+    /// gateway without re-signing. Always `None` for production bundles, and
+    /// always `None` regardless of the environment variable for any bundle
+    /// that isn't `AndroidStageWorldApp`.
+    #[must_use]
+    pub const fn certificate_sha256_digest_base64_alt(&self) -> Option<&'static str> {
+        match self {
+            Self::AndroidStageWorldApp => Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A="),
+            _ => None,
+        }
+    }
+
     #[must_use]
     pub const fn apple_app_id(&self) -> Option<&str> {
         match self {


### PR DESCRIPTION
## Summary

Consolidated follow-up to the closed PRs #154 through #158 (SEC-2307 through SEC-2311) plus local additions, rebased on top of the trust-anchor enforcement from #161 (SEC-2314). The Protected Confirmation experiment and the keybox-defense rate limiter have been removed from this PR; the latter lands separately as SEC-2275.

Stacks on top of #161.

## Changes

- `key_description`: ASN.1 parser now extracts every field we care about for risk scoring -- purpose, creation date, verified-boot key/hash, batch-cert serial, module hash, every `attestation_id_*`, plus `unique_id`, `attestation_version`, `os_version`, `vendor_patch_level`, `boot_patch_level`, `usage_count_limit`, `algorithm`, `key_size`, `ec_curve`.
- `device_certificate`: pub accessors for each new field.
- `android_ca_registry`: tracks the subset of roots that issue keys via Remote Key Provisioning (`is_rkp_root`) so we can mark RKP-rooted chains as keybox-bypass-impossible.
- `android_attestation_service`: new `IntegrityConfidence` aggregate exposing all signals (boot state, RKP, identity diversity, patch-level staleness, batch-cert serial, etc.); structured `tracing::info!` / `warn!` events at every verification step so we can feed Datadog with what we accepted and why.
- `routes/a.rs`: 5 optional informational request fields (`security_level`, `os_api_level`, `device_properties_included`, `integrity_signature`, `device_key_expires_at`) that the World App already sends on staging; structured per-request logging; embeds `IntegrityConfidence` in the issued integrity-token JWT under the `integrity_confidence` claim and in the `/a` response so verifying parties can do their own risk scoring.
- `utils`: optional alt signing-cert digest, gated behind `ATTESTATION_GATEWAY_ACCEPT_ALT_SIGNING_CERT=1` so the staging gateway can accept dev/test World App builds without re-signing. Off by default; production bundles unaffected.
- `main.rs` / `Cargo.toml`: `tracing-subscriber` now reads `RUST_LOG` via `EnvFilter`, so verbosity can be flipped without redeploying.

## Compatibility

No behavior change for accepted attestations: signals are additive and always-on logs. Untrusted attestations still get rejected at the same points they did before.

## Linear

[SEC-2276 -- Harden Android attested key generation](https://linear.app/worldcoin/issue/SEC-2276)

## Test plan

- [ ] CI: cargo check / clippy / fmt
- [ ] Submit a known-good attestation, confirm:
  - [ ] response includes `integrity_confidence`
  - [ ] issued JWT carries the `integrity_confidence` claim
  - [ ] structured logs in Datadog include all new fields
- [ ] Toggle `RUST_LOG=trace` and confirm verbosity actually changes
- [ ] Set `ATTESTATION_GATEWAY_ACCEPT_ALT_SIGNING_CERT=1` on staging, attest from a dev-signed World App build, confirm acceptance
- [ ] Unset the env var, retry, confirm rejection