### PR TITLE
Rate limit android attestation

### DIFF
--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -5,12 +5,14 @@ use crate::{
         cert_chain_builder::{
             CertChainBuilder, CertChainBuilderBuildChainError, CertChainBuilderNewError,
         },
+        rate_limit_service::{RateLimitService, RateLimitServiceTryIncrError},
         revocation_list::{RevocationList, RevocationListError},
     },
     utils::BundleIdentifier,
 };
 use base64::{DecodeError, Engine, engine::general_purpose::STANDARD as Base64};
 use chrono::{DateTime, Datelike, Utc};
+use redis::aio::ConnectionManager;
 use thiserror::Error;
 
 /// Android `KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT` — `KeyMint` / Keymaster in the TEE.
@@ -27,11 +29,17 @@ const KM_ORIGIN_GENERATED: u64 = 0;
 
 #[derive(Debug, Error)]
 pub enum AndroidAttestationError {
+    #[error("rate limit service try incr error: {0}")]
+    InternalRateLimitServiceTryIncr(#[source] RateLimitServiceTryIncrError),
+
     #[error("cert chain builder new error: {0}")]
     CertChainBuilderNew(#[source] CertChainBuilderNewError),
 
     #[error("revocation list: {0}")]
     RevocationList(#[source] RevocationListError),
+
+    #[error("rate limit exceeded")]
+    RateLimitExceeded,
 
     #[error("invalid challenge")]
     InvalidChallenge,
@@ -91,6 +99,7 @@ pub struct AndroidAttestationOutput {
 pub struct AndroidAttestationService {
     cert_chain_builder: CertChainBuilder,
     revocation_list: RevocationList,
+    rate_limit_service: RateLimitService,
 }
 
 impl AndroidAttestationService {
@@ -98,15 +107,17 @@ impl AndroidAttestationService {
     pub const fn new(
         cert_chain_builder: CertChainBuilder,
         revocation_list: RevocationList,
+        rate_limit_service: RateLimitService,
     ) -> Self {
         Self {
             cert_chain_builder,
             revocation_list,
+            rate_limit_service,
         }
     }
 
     /// Loads bundled Android attestation root CAs and fetches the default Google revocation feed.
-    pub async fn from_defaults() -> Result<Self, AndroidAttestationError> {
+    pub async fn from_defaults(redis: ConnectionManager) -> Result<Self, AndroidAttestationError> {
         let cert_chain_builder = CertChainBuilder::new_from_default_pem()
             .map_err(AndroidAttestationError::CertChainBuilderNew)?;
 
@@ -114,7 +125,13 @@ impl AndroidAttestationService {
             .await
             .map_err(AndroidAttestationError::RevocationList)?;
 
-        Ok(Self::new(cert_chain_builder, revocation_list))
+        let rate_limit_service = RateLimitService::new(redis);
+
+        Ok(Self::new(
+            cert_chain_builder,
+            revocation_list,
+            rate_limit_service,
+        ))
     }
 
     /// Background refresh for the revocation list; see [`AndroidRevocationList::spawn_refresh_loop`].
@@ -123,8 +140,8 @@ impl AndroidAttestationService {
         self.revocation_list.spawn_refresh_loop()
     }
 
-    pub fn verify(
-        &self,
+    pub async fn verify(
+        &mut self,
         base64_cert_chain: &[String],
         nonce: &String,
         app_version: &String,
@@ -134,6 +151,16 @@ impl AndroidAttestationService {
             .cert_chain_builder
             .build_chain_from_base64(base64_cert_chain)
             .map_err(AndroidAttestationError::CertChainBuilderBuildChain)?;
+
+        let rate_limit_passed = self
+            .rate_limit_service
+            .try_incr(&cert_chain)
+            .await
+            .map_err(AndroidAttestationError::InternalRateLimitServiceTryIncr)?;
+
+        if !rate_limit_passed {
+            return Err(AndroidAttestationError::RateLimitExceeded);
+        }
 
         if cert_chain
             .serials()
@@ -236,10 +263,14 @@ impl AndroidAttestationService {
 impl AndroidAttestationError {
     pub fn reason_tag(&self) -> String {
         match self {
+            Self::InternalRateLimitServiceTryIncr(e) => {
+                format!("rate_limit_service_try_incr_{}", e.reason_tag())
+            }
             Self::CertChainBuilderNew(_) => "cert_chain_builder_new".to_string(),
             Self::RevocationList(e) => {
                 format!("revocation_list_{}", e.reason_tag())
             }
+            Self::RateLimitExceeded => "rate_limit_exceeded".to_string(),
             Self::InvalidChallenge => "invalid_challenge".to_string(),
             Self::LowSecurityLevel => "low_security_level".to_string(),
             Self::InconsistentSecurityLevels => "inconsistent_security_levels".to_string(),
@@ -269,10 +300,11 @@ impl AndroidAttestationError {
 
     pub const fn is_internal_error(&self) -> bool {
         match self {
-            Self::CertChainBuilderNew(_) => true,
+            Self::InternalRateLimitServiceTryIncr(_) | Self::CertChainBuilderNew(_) => true,
             Self::RevocationList(e) => e.is_internal_error(),
             Self::CertChainBuilderBuildChain(e) => e.is_internal_error(),
-            Self::InvalidChallenge
+            Self::RateLimitExceeded
+            | Self::InvalidChallenge
             | Self::LowSecurityLevel
             | Self::InconsistentSecurityLevels
             | Self::DeviceNotLocked

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -117,7 +117,10 @@ impl AndroidAttestationService {
     }
 
     /// Loads bundled Android attestation root CAs and fetches the default Google revocation feed.
-    pub async fn from_defaults(redis: ConnectionManager) -> Result<Self, AndroidAttestationError> {
+    pub async fn from_defaults(
+        redis: ConnectionManager,
+        limit_per_day: isize,
+    ) -> Result<Self, AndroidAttestationError> {
         let cert_chain_builder = CertChainBuilder::new_from_default_pem()
             .map_err(AndroidAttestationError::CertChainBuilderNew)?;
 
@@ -125,7 +128,7 @@ impl AndroidAttestationService {
             .await
             .map_err(AndroidAttestationError::RevocationList)?;
 
-        let rate_limit_service = RateLimitService::new(redis);
+        let rate_limit_service = RateLimitService::new(redis, limit_per_day);
 
         Ok(Self::new(
             cert_chain_builder,

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -119,7 +119,7 @@ impl AndroidAttestationService {
     /// Loads bundled Android attestation root CAs and fetches the default Google revocation feed.
     pub async fn from_defaults(
         redis: ConnectionManager,
-        limit_per_day: isize,
+        limit_per_day: Option<isize>,
     ) -> Result<Self, AndroidAttestationError> {
         let cert_chain_builder = CertChainBuilder::new_from_default_pem()
             .map_err(AndroidAttestationError::CertChainBuilderNew)?;

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -143,6 +143,7 @@ impl AndroidAttestationService {
     pub async fn verify(
         &mut self,
         base64_cert_chain: &[String],
+        aud: &str,
         nonce: &String,
         app_version: &String,
         bundle_identifier: &BundleIdentifier,
@@ -154,7 +155,7 @@ impl AndroidAttestationService {
 
         let rate_limit_passed = self
             .rate_limit_service
-            .try_incr(&cert_chain)
+            .try_incr(aud, &cert_chain)
             .await
             .map_err(AndroidAttestationError::InternalRateLimitServiceTryIncr)?;
 

--- a/attestation-gateway/src/android/cert_chain.rs
+++ b/attestation-gateway/src/android/cert_chain.rs
@@ -67,6 +67,7 @@ impl CertSerial {
 
 pub struct CertChain {
     session_cert: SessionCert,
+    device_cert: IntermediateCert,
     intermediate_certs: Vec<IntermediateCert>,
     root_cert: RootCert,
     serials: Vec<CertSerial>,
@@ -79,10 +80,14 @@ impl CertChain {
         }
 
         let (session_cert, tail_certs) = cert_chain.split_first().unwrap();
+        let (device_cert, tail_certs) = tail_certs.split_first().unwrap();
         let (root_cert, intermediate_certs) = tail_certs.split_last().unwrap();
 
         let session_cert =
             SessionCert::from_x509(session_cert).map_err(CertChainError::SessionCert)?;
+
+        let device_cert =
+            IntermediateCert::from_x509(device_cert).map_err(CertChainError::IntermediateCert)?;
 
         let intermediate_certs = intermediate_certs
             .iter()
@@ -99,6 +104,7 @@ impl CertChain {
 
         Ok(Self {
             session_cert,
+            device_cert,
             intermediate_certs,
             root_cert,
             serials,
@@ -114,6 +120,10 @@ impl CertChain {
 
     pub const fn session_cert(&self) -> &SessionCert {
         &self.session_cert
+    }
+
+    pub const fn device_cert(&self) -> &IntermediateCert {
+        &self.device_cert
     }
 
     pub const fn root_cert(&self) -> &RootCert {

--- a/attestation-gateway/src/android/intermediate_cert.rs
+++ b/attestation-gateway/src/android/intermediate_cert.rs
@@ -44,6 +44,14 @@ impl IntermediateCert {
 
         Ok(Self { public_key })
     }
+
+    pub fn public_key(&self) -> &[u8] {
+        &self.public_key
+    }
+
+    pub fn public_key_hex(&self) -> String {
+        hex::encode(self.public_key())
+    }
 }
 
 impl IntermediateCertError {

--- a/attestation-gateway/src/android/mod.rs
+++ b/attestation-gateway/src/android/mod.rs
@@ -10,6 +10,7 @@ mod cert_chain_builder;
 mod integrity_token_data;
 mod intermediate_cert;
 mod key_description;
+pub mod rate_limit_service;
 mod revocation_list;
 mod root_cert;
 mod session_cert;

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -12,11 +12,8 @@ pub struct RateLimitService {
 
 #[derive(Debug, Error)]
 pub enum RateLimitServiceTryIncrError {
-    #[error("redis increrror: {0}")]
-    RedisIncr(#[source] RedisError),
-
-    #[error("redis expire at error: {0}")]
-    RedisExpireAt(#[source] RedisError),
+    #[error("redis error: {0}")]
+    Redis(#[source] RedisError),
 }
 
 impl RateLimitService {
@@ -43,16 +40,13 @@ impl RateLimitService {
             device_public_key = cert_chain.device_cert().public_key_hex(),
         );
 
-        let todays_count = self
-            .redis
+        let (todays_count, _): (isize, bool) = redis::pipe()
+            .atomic()
             .incr(&key, 1)
+            .expire_at(key, tomorrow.timestamp() + 30)
+            .query_async(&mut self.redis)
             .await
-            .map_err(RateLimitServiceTryIncrError::RedisIncr)?;
-
-        self.redis
-            .expire_at(&key, tomorrow.timestamp() + 30) // 30s for clock drift
-            .await
-            .map_err(RateLimitServiceTryIncrError::RedisExpireAt)?;
+            .map_err(RateLimitServiceTryIncrError::Redis)?;
 
         Ok(todays_count <= self.limit_per_day)
     }
@@ -61,8 +55,7 @@ impl RateLimitService {
 impl RateLimitServiceTryIncrError {
     pub fn reason_tag(&self) -> String {
         match self {
-            Self::RedisIncr(_) => "redis_incr".to_string(),
-            Self::RedisExpireAt(_) => "redis_expire_at".to_string(),
+            Self::Redis(_) => "redis".to_string(),
         }
     }
 }

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -1,5 +1,5 @@
 use chrono::{Days, NaiveTime, Utc};
-use redis::{AsyncTypedCommands, RedisError, aio::ConnectionManager};
+use redis::{RedisError, aio::ConnectionManager};
 use thiserror::Error;
 
 use crate::android::cert_chain::CertChain;

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -4,11 +4,10 @@ use thiserror::Error;
 
 use crate::android::cert_chain::CertChain;
 
-const RATE_LIMIT_PER_DAY: isize = 10;
-
 #[derive(Debug, Clone)]
 pub struct RateLimitService {
     redis: ConnectionManager,
+    limit_per_day: isize,
 }
 
 #[derive(Debug, Error)]
@@ -22,8 +21,11 @@ pub enum RateLimitServiceTryIncrError {
 
 impl RateLimitService {
     #[must_use]
-    pub fn new(redis: ConnectionManager) -> Self {
-        Self { redis }
+    pub fn new(redis: ConnectionManager, limit_per_day: isize) -> Self {
+        Self {
+            redis,
+            limit_per_day,
+        }
     }
 
     pub async fn try_incr(
@@ -52,7 +54,7 @@ impl RateLimitService {
             .await
             .map_err(RateLimitServiceTryIncrError::RedisExpireAt)?;
 
-        Ok(todays_count <= RATE_LIMIT_PER_DAY)
+        Ok(todays_count <= self.limit_per_day)
     }
 }
 

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -40,7 +40,7 @@ impl RateLimitService {
             device_public_key = cert_chain.device_cert().public_key_hex(),
         );
 
-        let (todays_count, _): (isize, bool) = redis::pipe()
+        let (todays_count, _expiration_set): (isize, bool) = redis::pipe()
             .atomic()
             .incr(&key, 1)
             .expire_at(key, tomorrow.timestamp() + 30)

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -28,15 +28,17 @@ impl RateLimitService {
 
     pub async fn try_incr(
         &mut self,
+        aud: &str,
         cert_chain: &CertChain,
     ) -> Result<bool, RateLimitServiceTryIncrError> {
         let today = Utc::now().with_time(NaiveTime::MIN).single().unwrap();
         let tomorrow = today.checked_add_days(Days::new(1)).unwrap();
 
         let key = format!(
-            "android:rate_limit_service:{}:{}",
-            today.format("%Y-%m-%d"),
-            cert_chain.device_cert().public_key_hex(),
+            "android:rate_limit_service:{aud}:{date}:{device_public_key}",
+            aud = aud,
+            date = today.format("%Y-%m-%d"),
+            device_public_key = cert_chain.device_cert().public_key_hex(),
         );
 
         let count = self

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -41,7 +41,7 @@ impl RateLimitService {
             device_public_key = cert_chain.device_cert().public_key_hex(),
         );
 
-        let count = self
+        let todays_count = self
             .redis
             .incr(&key, 1)
             .await
@@ -52,7 +52,7 @@ impl RateLimitService {
             .await
             .map_err(RateLimitServiceTryIncrError::RedisExpireAt)?;
 
-        Ok(count <= RATE_LIMIT_PER_DAY)
+        Ok(todays_count <= RATE_LIMIT_PER_DAY)
     }
 }
 

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -7,7 +7,7 @@ use crate::android::cert_chain::CertChain;
 #[derive(Debug, Clone)]
 pub struct RateLimitService {
     redis: ConnectionManager,
-    limit_per_day: isize,
+    limit_per_day: Option<isize>,
 }
 
 #[derive(Debug, Error)]
@@ -18,7 +18,7 @@ pub enum RateLimitServiceTryIncrError {
 
 impl RateLimitService {
     #[must_use]
-    pub fn new(redis: ConnectionManager, limit_per_day: isize) -> Self {
+    pub fn new(redis: ConnectionManager, limit_per_day: Option<isize>) -> Self {
         Self {
             redis,
             limit_per_day,
@@ -30,6 +30,10 @@ impl RateLimitService {
         aud: &str,
         cert_chain: &CertChain,
     ) -> Result<bool, RateLimitServiceTryIncrError> {
+        let Some(limit) = self.limit_per_day else {
+            return Ok(true);
+        };
+
         let today = Utc::now().with_time(NaiveTime::MIN).single().unwrap();
         let tomorrow = today.checked_add_days(Days::new(1)).unwrap();
 
@@ -48,7 +52,7 @@ impl RateLimitService {
             .await
             .map_err(RateLimitServiceTryIncrError::Redis)?;
 
-        Ok(todays_count <= self.limit_per_day)
+        Ok(todays_count <= limit)
     }
 }
 

--- a/attestation-gateway/src/android/rate_limit_service.rs
+++ b/attestation-gateway/src/android/rate_limit_service.rs
@@ -1,0 +1,64 @@
+use chrono::{Days, NaiveTime, Utc};
+use redis::{AsyncTypedCommands, RedisError, aio::ConnectionManager};
+use thiserror::Error;
+
+use crate::android::cert_chain::CertChain;
+
+const RATE_LIMIT_PER_DAY: isize = 10;
+
+#[derive(Debug, Clone)]
+pub struct RateLimitService {
+    redis: ConnectionManager,
+}
+
+#[derive(Debug, Error)]
+pub enum RateLimitServiceTryIncrError {
+    #[error("redis increrror: {0}")]
+    RedisIncr(#[source] RedisError),
+
+    #[error("redis expire at error: {0}")]
+    RedisExpireAt(#[source] RedisError),
+}
+
+impl RateLimitService {
+    #[must_use]
+    pub fn new(redis: ConnectionManager) -> Self {
+        Self { redis }
+    }
+
+    pub async fn try_incr(
+        &mut self,
+        cert_chain: &CertChain,
+    ) -> Result<bool, RateLimitServiceTryIncrError> {
+        let today = Utc::now().with_time(NaiveTime::MIN).single().unwrap();
+        let tomorrow = today.checked_add_days(Days::new(1)).unwrap();
+
+        let key = format!(
+            "android:rate_limit_service:{}:{}",
+            today.format("%Y-%m-%d"),
+            cert_chain.device_cert().public_key_hex(),
+        );
+
+        let count = self
+            .redis
+            .incr(&key, 1)
+            .await
+            .map_err(RateLimitServiceTryIncrError::RedisIncr)?;
+
+        self.redis
+            .expire_at(&key, tomorrow.timestamp() + 30) // 30s for clock drift
+            .await
+            .map_err(RateLimitServiceTryIncrError::RedisExpireAt)?;
+
+        Ok(count <= RATE_LIMIT_PER_DAY)
+    }
+}
+
+impl RateLimitServiceTryIncrError {
+    pub fn reason_tag(&self) -> String {
+        match self {
+            Self::RedisIncr(_) => "redis_incr".to_string(),
+            Self::RedisExpireAt(_) => "redis_expire_at".to_string(),
+        }
+    }
+}

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -122,6 +122,22 @@ pub async fn handler(
         });
     }
 
+    let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
+        if matches!(e, NonceDbError::NonceNotFound) {
+            RequestError {
+                code: ErrorCode::BadRequest,
+                details: Some("Nonce not found".to_string()),
+            }
+        } else {
+            tracing::error!(error = ?e, "Error consuming token nonce");
+
+            RequestError {
+                code: ErrorCode::InternalServerError,
+                details: Some("Error consuming token nonce".to_string()),
+            }
+        }
+    })?;
+
     let challenge = format!("n={},av={}", request.nonce, request.app_version);
     let platform = request.bundle_identifier.platform();
 
@@ -148,6 +164,7 @@ pub async fn handler(
             let attestation_result = android_attestation
                 .verify(
                     &android_cert_chain,
+                    &token_details.aud,
                     &request.nonce,
                     &request.app_version,
                     &request.bundle_identifier,
@@ -192,22 +209,6 @@ pub async fn handler(
 
     metrics::counter!("attestation_gateway.attestation", "platform" => platform.to_string())
         .increment(1);
-
-    let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
-        if matches!(e, NonceDbError::NonceNotFound) {
-            RequestError {
-                code: ErrorCode::BadRequest,
-                details: Some("Nonce not found".to_string()),
-            }
-        } else {
-            tracing::error!(error = ?e, "Error consuming token nonce");
-
-            RequestError {
-                code: ErrorCode::InternalServerError,
-                details: Some("Error consuming token nonce".to_string()),
-            }
-        }
-    })?;
 
     let exp = match request.exp {
         Some(exp) => {

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -4,7 +4,7 @@ use aws_config::SdkConfig;
 
 use axum::{Extension, Json};
 use base64::{Engine, engine::general_purpose::STANDARD as Base64};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SubsecRound, Utc};
 use josekit::jwt::JwtPayload;
 use openssl::{
     bn::BigNum,
@@ -77,7 +77,7 @@ impl IntegrityTokenPayload {
         cfn.insert("jwk".to_string(), josekit::Value::Object(cnf_jwk.into()));
 
         let mut payload = JwtPayload::new();
-        payload.set_issued_at(&SystemTime::now());
+        payload.set_issued_at(&Utc::now().round_subsecs(0).into());
         payload.set_issuer("attestation.worldcoin.org"); // TODO: what about attestation.worldcoin.dev?
         payload.set_expires_at(
             &DateTime::<Utc>::from_timestamp(self.exp, 0)

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -105,7 +105,7 @@ pub async fn handler(
     Extension(global_config): Extension<GlobalConfig>,
     Extension(mut redis): Extension<ConnectionManager>,
     Extension(mut nonce_db): Extension<NonceDb>,
-    Extension(android_attestation): Extension<AndroidAttestationService>,
+    Extension(mut android_attestation): Extension<AndroidAttestationService>,
     Extension(aws_config): Extension<SdkConfig>,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
@@ -145,12 +145,14 @@ pub async fn handler(
                 details: Some("Android attestation is required".to_string()),
             })?;
 
-            let attestation_result = android_attestation.verify(
-                &android_cert_chain,
-                &request.nonce,
-                &request.app_version,
-                &request.bundle_identifier,
-            );
+            let attestation_result = android_attestation
+                .verify(
+                    &android_cert_chain,
+                    &request.nonce,
+                    &request.app_version,
+                    &request.bundle_identifier,
+                )
+                .await;
 
             let attestation_output = match attestation_result {
                 Ok(attestation_output) => Ok(attestation_output),

--- a/attestation-gateway/src/server.rs
+++ b/attestation-gateway/src/server.rs
@@ -36,8 +36,10 @@ pub async fn start(
 
     let nonce_db = NonceDb::new(redis.clone());
 
-    let android_rate_limit_per_day =
-        env::var("ANDROID_RATE_LIMIT_PER_DAY").map_or(10, |v| v.parse().unwrap());
+    let android_rate_limit_per_day = env::var("ANDROID_RATE_LIMIT_PER_DAY")
+        .ok()
+        .map(|v| v.parse().expect("ANDROID_RATE_LIMIT_PER_DAY must be a valid isize"));
+
     let android_attestation_service =
         AndroidAttestationService::from_defaults(redis.clone(), android_rate_limit_per_day)
             .await

--- a/attestation-gateway/src/server.rs
+++ b/attestation-gateway/src/server.rs
@@ -35,7 +35,7 @@ pub async fn start(
     };
 
     let nonce_db = NonceDb::new(redis.clone());
-    let android_attestation_service = AndroidAttestationService::from_defaults()
+    let android_attestation_service = AndroidAttestationService::from_defaults(redis.clone())
         .await
         .expect("failed to construct Android attestation service");
 

--- a/attestation-gateway/src/server.rs
+++ b/attestation-gateway/src/server.rs
@@ -35,9 +35,13 @@ pub async fn start(
     };
 
     let nonce_db = NonceDb::new(redis.clone());
-    let android_attestation_service = AndroidAttestationService::from_defaults(redis.clone())
-        .await
-        .expect("failed to construct Android attestation service");
+
+    let android_rate_limit_per_day =
+        env::var("ANDROID_RATE_LIMIT_PER_DAY").map_or(10, |v| v.parse().unwrap());
+    let android_attestation_service =
+        AndroidAttestationService::from_defaults(redis.clone(), android_rate_limit_per_day)
+            .await
+            .expect("failed to construct Android attestation service");
 
     #[expect(clippy::let_underscore_future)] // do not await, it's a handler for background tasks
     let _ = android_attestation_service.spawn_refresh_loop();

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -127,7 +127,7 @@ async fn extension_android_attestation(
             list,
             attestation_gateway::android::rate_limit_service::RateLimitService::new(
                 redis.clone(),
-                10,
+                Some(10),
             ),
         ),
     )

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -107,8 +107,9 @@ fn extension_nonce_db(
     Extension(attestation_gateway::nonces::NonceDb::new(redis.clone()))
 }
 
-async fn extension_android_attestation()
--> Extension<attestation_gateway::android::AndroidAttestationService> {
+async fn extension_android_attestation(
+    redis: &redis::aio::ConnectionManager,
+) -> Extension<attestation_gateway::android::AndroidAttestationService> {
     let mut server = mockito::Server::new_async().await;
     let _m = server
         .mock("GET", "/status")
@@ -124,6 +125,7 @@ async fn extension_android_attestation()
         attestation_gateway::android::AndroidAttestationService::new(
             attestation_gateway::android::CertChainBuilder::new_from_default_pem().unwrap(),
             list,
+            attestation_gateway::android::rate_limit_service::RateLimitService::new(redis.clone()),
         ),
     )
 }
@@ -153,7 +155,7 @@ async fn get_api_router() -> aide::axum::ApiRouter {
     attestation_gateway::routes::handler()
         .layer(get_aws_config_extension().await)
         .layer(get_global_config_extension())
-        .layer(extension_android_attestation().await)
+        .layer(extension_android_attestation(&redis_ext.0).await)
         .layer(extension_nonce_db(&redis_ext.0))
         .layer(redis_ext)
         .layer(get_kinesis_extension().await)
@@ -655,7 +657,7 @@ async fn test_server_error_is_properly_logged() {
         attestation_gateway::routes::handler()
             .layer(get_aws_config_extension().await)
             .layer(get_local_config_extension())
-            .layer(extension_android_attestation().await)
+            .layer(extension_android_attestation(&redis_ext.0).await)
             .layer(extension_nonce_db(&redis_ext.0))
             .layer(redis_ext)
             .layer(get_kinesis_extension().await)
@@ -724,7 +726,7 @@ async fn test_apple_initial_attestation_e2e_success() {
     let api_router = attestation_gateway::routes::handler()
         .layer(get_aws_config_extension().await)
         .layer(get_global_config_extension_with_pem(test_data.root_ca_pem))
-        .layer(extension_android_attestation().await)
+        .layer(extension_android_attestation(&redis_ext.0).await)
         .layer(extension_nonce_db(&redis_ext.0))
         .layer(redis_ext)
         .layer(get_kinesis_extension().await);

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -125,7 +125,10 @@ async fn extension_android_attestation(
         attestation_gateway::android::AndroidAttestationService::new(
             attestation_gateway::android::CertChainBuilder::new_from_default_pem().unwrap(),
             list,
-            attestation_gateway::android::rate_limit_service::RateLimitService::new(redis.clone()),
+            attestation_gateway::android::rate_limit_service::RateLimitService::new(
+                redis.clone(),
+                10,
+            ),
         ),
     )
 }


### PR DESCRIPTION
Rate-limit android attestation to 10 requests per device per aud per day. I moved `consume_nonce()` up because rate-limiting requires knowing `aud`. Downside is that it now prevents hypothetical retries of validation errors.