### PR TITLE
Make /a endpoint JWT issuer configurable via env var

### DIFF
--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -50,7 +50,7 @@ pub struct IntegrityTokenPayload {
 }
 
 impl IntegrityTokenPayload {
-    pub fn generate(&self) -> eyre::Result<JwtPayload> {
+    pub fn generate(&self, issuer: &str) -> eyre::Result<JwtPayload> {
         if self.cnf.len() != 65 {
             return Err(eyre::eyre!("Invalid device public key"));
         }
@@ -78,7 +78,7 @@ impl IntegrityTokenPayload {
 
         let mut payload = JwtPayload::new();
         payload.set_issued_at(&Utc::now().round_subsecs(0).into());
-        payload.set_issuer("attestation.worldcoin.org"); // TODO: what about attestation.worldcoin.dev?
+        payload.set_issuer(issuer);
         payload.set_expires_at(
             &DateTime::<Utc>::from_timestamp(self.exp, 0)
                 .ok_or(eyre::Error::msg("Unreachable exp conversion"))?
@@ -227,6 +227,7 @@ pub async fn handler(
     let integrity_token = generate_integrity_token(
         &mut redis,
         &aws_config,
+        &global_config.jwt_issuer,
         IntegrityTokenPayload {
             v: "1".to_string(),
             platform,
@@ -279,9 +280,10 @@ fn validate_apple_attestation_and_get_device_public_key(
 async fn generate_integrity_token(
     redis: &mut ConnectionManager,
     aws_config: &SdkConfig,
+    issuer: &str,
     integrity_token_payload: IntegrityTokenPayload,
 ) -> Result<String, RequestError> {
-    let integrity_token_payload = integrity_token_payload.generate().map_err(|e| {
+    let integrity_token_payload = integrity_token_payload.generate(issuer).map_err(|e| {
         tracing::error!(error = ?e, "Error generating integrity token payload");
         RequestError {
             code: ErrorCode::InternalServerError,

--- a/attestation-gateway/src/server.rs
+++ b/attestation-gateway/src/server.rs
@@ -36,9 +36,10 @@ pub async fn start(
 
     let nonce_db = NonceDb::new(redis.clone());
 
-    let android_rate_limit_per_day = env::var("ANDROID_RATE_LIMIT_PER_DAY")
-        .ok()
-        .map(|v| v.parse().expect("ANDROID_RATE_LIMIT_PER_DAY must be a valid isize"));
+    let android_rate_limit_per_day = env::var("ANDROID_RATE_LIMIT_PER_DAY").ok().map(|v| {
+        v.parse()
+            .expect("ANDROID_RATE_LIMIT_PER_DAY must be a valid isize")
+    });
 
     let android_attestation_service =
         AndroidAttestationService::from_defaults(redis.clone(), android_rate_limit_per_day)

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -22,6 +22,7 @@ pub struct GlobalConfig {
     pub kinesis_stream_arn: Option<String>,
     pub apple_root_ca_pem: Vec<u8>,
     pub aud_whitelist: Vec<String>,
+    pub jwt_issuer: String,
 }
 
 impl GlobalConfig {
@@ -63,6 +64,9 @@ impl GlobalConfig {
             |val| val.split(',').map(str::to_string).collect(),
         );
 
+        let jwt_issuer =
+            env::var("JWT_ISSUER").unwrap_or_else(|_| "attestation.worldcoin.org".to_string());
+
         tracing::info!(
             "Running with enabled bundle identifiers: {:?}",
             enabled_bundle_identifiers
@@ -78,6 +82,7 @@ impl GlobalConfig {
             kinesis_stream_arn,
             apple_root_ca_pem: include_bytes!("apple/apple_app_attestation_root_ca.pem").to_vec(),
             aud_whitelist,
+            jwt_issuer,
         }
     }
 }

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -97,6 +97,7 @@ fn get_global_config_extension_with_pem(
         developer_inner_jwks_url: std::env::var("DEVELOPER_INNER_JWKS_URL").ok(),
         apple_root_ca_pem,
         aud_whitelist: vec!["relying-party.example.com".to_string()],
+        jwt_issuer: "attestation.worldcoin.org".to_string(),
     };
     Extension(config)
 }
@@ -651,6 +652,7 @@ async fn test_server_error_is_properly_logged() {
             apple_root_ca_pem: include_bytes!("../src/apple/apple_app_attestation_root_ca.pem")
                 .to_vec(),
             aud_whitelist: vec!["relying-party.example.com".to_string()],
+            jwt_issuer: "attestation.worldcoin.org".to_string(),
         };
         Extension(config)
     }


### PR DESCRIPTION
- added `jwt_issuer` field to `GlobalConfig`, read from `JWT_ISSUER` (defaults to `attestation.worldcoin.org`)
- updated `IntegrityTokenPayload::generate()` to accept `issuer: &str`
- threaded issuer from `global_config` through `generate_integrity_token()`