### PR TITLE
android: parse optional Play Integrity verdict fields (MCORE-1202)

### DIFF
--- a/attestation-gateway/src/android/integrity_token_data.rs
+++ b/attestation-gateway/src/android/integrity_token_data.rs
@@ -35,10 +35,17 @@ pub struct RecentDeviceActivity {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DeviceAttributes {
+    pub sdk_version: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DeviceIntegrity {
     pub device_recognition_verdict: Option<Vec<String>>,
     pub legacy_device_recognition_verdict: Option<Vec<String>>,
     pub recent_device_activity: Option<RecentDeviceActivity>,
+    pub device_attributes: Option<DeviceAttributes>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -391,6 +398,7 @@ mod tests {
                 device_recognition_verdict: Some(vec!["MEETS_DEVICE_INTEGRITY".to_string()]),
                 legacy_device_recognition_verdict: None,
                 recent_device_activity: None,
+                device_attributes: None,
             },
             environment_details: Some(EnvironmentDetails {
                 app_access_risk_verdict: AppAccessRiskVerdict {
@@ -791,6 +799,121 @@ mod tests {
         let no_apps_detected: EnvironmentDetails =
             serde_json::from_str(no_apps_detected_json).unwrap();
         assert_eq!(no_apps_detected.app_access_risk_verdict.apps_detected, None);
+    }
+
+    /// Tests parsing of the three optional Play Integrity verdict fields that are opt-in via the
+    /// Play Console: `deviceIntegrity.recentDeviceActivity.deviceActivityLevel`,
+    /// `deviceIntegrity.deviceAttributes.sdkVersion`, and `environmentDetails.playProtectVerdict`.
+    ///
+    /// Reference: <https://developer.android.com/google/play/integrity/verdicts#optional-device-information>
+    #[test]
+    fn test_optional_verdict_fields_parsed_as_expected() {
+        // cspell:disable
+        let token_payload_str = r#"
+        {
+            "requestDetails": {
+                "requestPackageName": "com.worldcoin.staging",
+                "nonce": "i_am_a_sample_request_hash",
+                "timestampMillis": "1745276275999"
+            },
+            "appIntegrity": {
+                "appRecognitionVerdict": "PLAY_RECOGNIZED",
+                "packageName": "com.worldcoin.staging",
+                "certificateSha256Digest": [
+                    "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8"
+                ],
+                "versionCode": "25700"
+            },
+            "deviceIntegrity": {
+                "deviceRecognitionVerdict": [
+                    "MEETS_DEVICE_INTEGRITY",
+                    "MEETS_STRONG_INTEGRITY"
+                ],
+                "recentDeviceActivity": {
+                    "deviceActivityLevel": "LEVEL_2"
+                },
+                "deviceAttributes": {
+                    "sdkVersion": 33
+                }
+            },
+            "accountDetails": {
+                "appLicensingVerdict": "LICENSED"
+            },
+            "environmentDetails": {
+                "appAccessRiskVerdict": {
+                    "appsDetected": [
+                        "KNOWN_INSTALLED",
+                        "UNKNOWN_INSTALLED"
+                    ]
+                },
+                "playProtectVerdict": "NO_ISSUES"
+            }
+        }"#;
+        // cspell:enable
+
+        let token = PlayIntegrityToken::from_json(token_payload_str).unwrap();
+
+        let activity = token
+            .device_integrity
+            .recent_device_activity
+            .expect("recent_device_activity should be present");
+        assert_eq!(activity.device_activity_level, "LEVEL_2");
+
+        let attributes = token
+            .device_integrity
+            .device_attributes
+            .expect("device_attributes should be present");
+        assert_eq!(attributes.sdk_version, Some(33));
+
+        let env = token
+            .environment_details
+            .expect("environment_details should be present");
+        assert_eq!(env.play_protect_verdict, Some(PlayProtectVerdict::NoIssues));
+    }
+
+    /// Tests that the optional verdict fields are absent before opt-in (current production state)
+    /// and that the absence does not break parsing.
+    #[test]
+    fn test_optional_verdict_fields_absent_parses_cleanly() {
+        let token_payload_str = r#"
+        {
+            "requestDetails": {
+                "requestPackageName": "com.worldcoin.staging",
+                "nonce": "i_am_a_sample_request_hash",
+                "timestampMillis": "1745276275999"
+            },
+            "appIntegrity": {
+                "appRecognitionVerdict": "PLAY_RECOGNIZED",
+                "packageName": "com.worldcoin.staging",
+                "certificateSha256Digest": [
+                    "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8"
+                ],
+                "versionCode": "25700"
+            },
+            "deviceIntegrity": {
+                "deviceRecognitionVerdict": ["MEETS_DEVICE_INTEGRITY"]
+            },
+            "accountDetails": {
+                "appLicensingVerdict": "LICENSED"
+            },
+            "environmentDetails": {
+                "appAccessRiskVerdict": {
+                    "appsDetected": ["KNOWN_INSTALLED", "UNKNOWN_INSTALLED"]
+                }
+            }
+        }"#;
+
+        let token = PlayIntegrityToken::from_json(token_payload_str).unwrap();
+
+        assert!(token.device_integrity.recent_device_activity.is_none());
+        assert!(token.device_integrity.device_attributes.is_none());
+        assert!(
+            token
+                .environment_details
+                .unwrap()
+                .play_protect_verdict
+                .is_none()
+        );
     }
 
     /// Tests that a token with an `unevaluated` verdict is properly parsed and integrity failure is logged as such.


### PR DESCRIPTION
## Summary

Adds the AG-side parsing for the three optional Play Integrity verdict fields that [MCORE-1202](https://linear.app/worldcoin/issue/MCORE-1202/opt-in-to-play-integrity-optional-fields-recentdeviceactivity) opts into in the Play Console:

- `deviceIntegrity.recentDeviceActivity.deviceActivityLevel`
- `environmentDetails.playProtectVerdict`
- `deviceIntegrity.deviceAttributes.sdkVersion`

The first two were already typed in `integrity_token_data.rs` (`RecentDeviceActivity`, `PlayProtectVerdict`) and flow through `DataReport` to Kinesis / Snowflake without change. The third (`sdkVersion`) was not yet modeled, so today it would be silently dropped by serde during deserialization and never reach the data lake. This PR adds the missing `DeviceAttributes` struct so all three fields land once the Play Console toggle is flipped.

## Why

Per a 60-day Snowflake export of `ddm_bi_seon.attestation_gateway` (n=18.5M passing requests):

- `playProtectVerdict` and `deviceActivityLevel` are null in 100% of rows.
- `deviceAttributes.sdkVersion` is the third signal we want for tiered enforcement (Android 13+ vs Android 12 vs older) and is similarly absent.

These three fields are the most useful Play Integrity discriminators against the no-STRONG bucket that we do not currently collect. Prior context: MCORE-230 / APP-8988 (both closed Jun 2025) confirmed the Rust parser was already in place for `recentDeviceActivity`, but the Play Console toggle was never flipped, so no data ever flowed. MCORE-1202 covers the toggle; this PR covers the prerequisite struct extension.

## Change

`attestation-gateway/src/android/integrity_token_data.rs`:

- New `DeviceAttributes { sdk_version: Option<u32> }` struct (camelCase rename).
- New `device_attributes: Option<DeviceAttributes>` field on `DeviceIntegrity`.
- `create_test_token` updated to populate `device_attributes: None`.
- Two parsing tests added:
  - `test_optional_verdict_fields_parsed_as_expected` — the post-opt-in payload shape with all three fields populated.
  - `test_optional_verdict_fields_absent_parses_cleanly` — the current production shape, to lock in backward compatibility.

No behavior changes. `PlayProtectVerdict::HighRisk` continues to fail validation as it does today, and no other validator logic is touched.

## Test plan

- [x] `cargo test android::integrity_token_data` — 12 tests pass, including the two new ones
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` on the changed file — no new warnings
- [ ] Merge after MCORE-1202 Play Console toggle is flipped, or before with no functional impact (struct is additive, all three fields are `Option<_>`)

## Related

- Linear: [MCORE-1202](https://linear.app/worldcoin/issue/MCORE-1202/opt-in-to-play-integrity-optional-fields-recentdeviceactivity)
- Linear (closed predecessors): [MCORE-230](https://linear.app/worldcoin/issue/MCORE-230/implement-recent-device-activity-feature-in-the-play-integrity-api), [APP-8988](https://linear.app/worldcoin/issue/APP-8988/include-recent-device-activityin-attestation-gw)
- Linear (downstream consumer): [SEC-2419](https://linear.app/worldcoin/issue/SEC-2419/fc-rt-07-keybox-attestation-bypass-on-g-route-medium)
- Google docs: [Integrity verdicts](https://developer.android.com/google/play/integrity/verdicts#optional-device-information), [Setup](https://developer.android.com/google/play/integrity/setup#configure-api)