### PR TITLE
Update LP token obtaining to derive it from Authorization header

### DIFF
--- a/attestation-gateway/src/routes/generate_token.rs
+++ b/attestation-gateway/src/routes/generate_token.rs
@@ -1,5 +1,8 @@
 use aws_sdk_kinesis::Client as KinesisClient;
-use axum::Extension;
+use axum::{
+    Extension,
+    http::{HeaderMap, header},
+};
 use axum_jsonschema::Json;
 use redis::{AsyncCommands, ExistenceCheck, SetExpiry, SetOptions, aio::ConnectionManager};
 use std::time::SystemTime;
@@ -26,6 +29,7 @@ pub async fn handler(
     Extension(mut redis): Extension<ConnectionManager>,
     Extension(global_config): Extension<GlobalConfig>,
     Extension(kinesis_client): Extension<KinesisClient>,
+    headers: HeaderMap,
     Json(request): Json<TokenGenerationRequest>,
 ) -> Result<Json<TokenGenerationResponse>, RequestError> {
     let aud = request.aud.clone();
@@ -40,7 +44,13 @@ pub async fn handler(
 
     let _enter = my_span.enter();
 
-    let integrity_verification_input = IntegrityVerificationInput::from_request(&request)?;
+    // Laissez-passer token (a.k.a. developer token) is transported in the
+    // `Authorization: Bearer ...` header. When present, it bypasses platform
+    // attestation and is verified against the issuer JWKS instead.
+    let laissez_passer_token = extract_bearer_token(&headers)?;
+
+    let integrity_verification_input =
+        IntegrityVerificationInput::from_request(&request, laissez_passer_token)?;
 
     handle_client_error_if_applicable(
         &integrity_verification_input,
@@ -392,4 +402,38 @@ async fn handle_client_error_if_applicable(
     }
 
     Ok(())
+}
+
+/// Extracts a laissez-passer bearer token from the `Authorization` header.
+///
+/// Returns `Ok(None)` when the header is absent (i.e. a regular Android/Apple attestation
+/// request). Returns `Ok(Some(token))` for a well-formed `Authorization: Bearer <token>`.
+/// Returns `RequestError` with [`ErrorCode::InvalidDeveloperToken`] if the header is present
+/// but malformed (non-ASCII, missing scheme, missing token, or wrong scheme).
+fn extract_bearer_token(headers: &HeaderMap) -> Result<Option<String>, RequestError> {
+    let Some(value) = headers.get(header::AUTHORIZATION) else {
+        return Ok(None);
+    };
+
+    let raw = value.to_str().map_err(|_| RequestError {
+        code: ErrorCode::InvalidDeveloperToken,
+        details: Some("Invalid `Authorization` header value.".to_string()),
+    })?;
+
+    let Some(token) = raw.strip_prefix("Bearer ") else {
+        return Err(RequestError {
+            code: ErrorCode::InvalidDeveloperToken,
+            details: Some("`Authorization` header must use the `Bearer` scheme.".to_string()),
+        });
+    };
+
+    let token = token.trim();
+    if token.is_empty() {
+        return Err(RequestError {
+            code: ErrorCode::InvalidDeveloperToken,
+            details: Some("`Authorization: Bearer` token is empty.".to_string()),
+        });
+    }
+
+    Ok(Some(token.to_string()))
 }

--- a/attestation-gateway/src/routes/generate_token.rs
+++ b/attestation-gateway/src/routes/generate_token.rs
@@ -410,6 +410,8 @@ async fn handle_client_error_if_applicable(
 /// request). Returns `Ok(Some(token))` for a well-formed `Authorization: Bearer <token>`.
 /// Returns `RequestError` with [`ErrorCode::InvalidDeveloperToken`] if the header is present
 /// but malformed (non-ASCII, missing scheme, missing token, or wrong scheme).
+///
+/// The auth scheme name is matched case-insensitively, per RFC 7235 §2.1.
 fn extract_bearer_token(headers: &HeaderMap) -> Result<Option<String>, RequestError> {
     let Some(value) = headers.get(header::AUTHORIZATION) else {
         return Ok(None);
@@ -420,12 +422,17 @@ fn extract_bearer_token(headers: &HeaderMap) -> Result<Option<String>, RequestEr
         details: Some("Invalid `Authorization` header value.".to_string()),
     })?;
 
-    let Some(token) = raw.strip_prefix("Bearer ") else {
+    let (scheme, token) = raw.split_once(char::is_whitespace).ok_or(RequestError {
+        code: ErrorCode::InvalidDeveloperToken,
+        details: Some("`Authorization` header must use the `Bearer` scheme.".to_string()),
+    })?;
+
+    if !scheme.eq_ignore_ascii_case("Bearer") {
         return Err(RequestError {
             code: ErrorCode::InvalidDeveloperToken,
             details: Some("`Authorization` header must use the `Bearer` scheme.".to_string()),
         });
-    };
+    }
 
     let token = token.trim();
     if token.is_empty() {

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -232,7 +232,6 @@ pub struct TokenGenerationRequest {
     pub apple_initial_attestation: Option<String>,
     pub apple_public_key: Option<String>,
     pub apple_assertion: Option<String>,
-    pub developer_token: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize, JsonSchema)]
@@ -264,17 +263,24 @@ pub enum IntegrityVerificationInput {
 impl IntegrityVerificationInput {
     /// Parses a `TokenGenerationRequest` into an `IntegrityVerificationInput` specifically for an Android or Apple integrity check.
     ///
+    /// The optional `laissez_passer_token` is the bearer token extracted from the `Authorization`
+    /// header. When present, it takes precedence over the platform-specific attestation flows
+    /// and is routed to the Developer (laissez-passer) verification path.
+    ///
     /// # Errors
     /// Will return a `RequestError` if the request is malformed or missing required fields.
     ///
     /// # Panics
     /// No panics expected.
-    pub fn from_request(request: &TokenGenerationRequest) -> Result<Self, RequestError> {
+    pub fn from_request(
+        request: &TokenGenerationRequest,
+        laissez_passer_token: Option<String>,
+    ) -> Result<Self, RequestError> {
         if let Some(client_error) = request.client_error.clone() {
             return Ok(Self::ClientError { client_error });
         }
 
-        if let Some(developer_token) = request.developer_token.clone() {
+        if let Some(developer_token) = laissez_passer_token {
             return Ok(Self::Developer { developer_token });
         }
 

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -269,7 +269,6 @@ async fn test_android_e2e_success() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -414,7 +413,6 @@ async fn test_android_token_generation_with_invalid_attributes() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -462,7 +460,6 @@ async fn test_token_generation_fails_on_duplicate_request_hash() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -531,7 +528,6 @@ async fn test_request_hash_race_condition() {
             apple_initial_attestation: None,
             apple_public_key: None,
             apple_assertion: None,
-            developer_token: None,
         };
 
         let handle = task::spawn(
@@ -593,7 +589,6 @@ async fn test_request_hash_is_released_if_request_fails() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -679,7 +674,6 @@ async fn test_server_error_is_properly_logged() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -748,7 +742,6 @@ async fn test_apple_initial_attestation_e2e_success() {
         apple_initial_attestation: Some(test_data.attestation_base64.clone()),
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -870,7 +863,6 @@ async fn test_apple_token_generation_with_invalid_attributes_for_initial_attesta
         apple_initial_attestation: Some("ou000000000000000000".to_string()),
         apple_public_key: Some("0x00000000000000000000000000000000".to_string()),
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -936,7 +928,6 @@ async fn test_apple_assertion_e2e_success() {
         apple_initial_attestation: None,
         apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
         apple_assertion: Some(TEST_VALID_ASSERTION.to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1030,7 +1021,6 @@ async fn test_apple_token_generation_with_an_invalid_base_64_assertion_generates
         apple_initial_attestation: None,
         apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
         apple_assertion: Some("not_even_base64".to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1095,7 +1085,6 @@ async fn test_apple_token_generation_with_an_invalid_assertion_generates_a_clien
         apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
         // Valid base64 but invalid CBOR message
         apple_assertion: Some("aW52YWxpZA".to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1144,7 +1133,6 @@ async fn test_apple_token_generation_with_invalid_attributes_for_assertion() {
         apple_initial_attestation: None,
         apple_public_key: Some("0x00000000000000000000000000000000".to_string()),
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1191,7 +1179,6 @@ async fn test_apple_token_generation_assertion_with_an_invalid_key_id() {
         apple_initial_attestation: None,
         apple_public_key: Some("0x00000000000000000000000000000000".to_string()),
         apple_assertion: Some("0x00000000000000000000000000000000".to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1255,7 +1242,6 @@ async fn test_apple_token_generation_assertion_with_an_invalidly_signed_assertio
         apple_initial_attestation: None,
         apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
         apple_assertion: Some(invalid_assertion.to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1319,7 +1305,6 @@ async fn test_apple_token_generation_assertion_with_an_invalid_key_bundle_identi
         apple_initial_attestation: None,
         apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
         apple_assertion: Some(TEST_VALID_ASSERTION.to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1398,7 +1383,6 @@ async fn test_apple_token_generation_with_invalid_counter() {
         apple_initial_attestation: None,
         apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
         apple_assertion: Some(TEST_VALID_ASSERTION.to_string()),
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1535,7 +1519,6 @@ async fn test_apple_counter_race_condition() {
             apple_initial_attestation: None,
             apple_public_key: Some(TEST_ATTESTATION_KEY_ID.to_string()),
             apple_assertion: Some(assertion.to_string()),
-            developer_token: None,
         };
 
         let handle = task::spawn(
@@ -1756,7 +1739,8 @@ async fn test_developer_token_generation_e2e_success() {
     let generated_client_token =
         generate_client_token(&client_jwk, developer_certificate, &request_hash);
 
-    // Generate token generation request
+    // Generate token generation request (developer token now travels in the
+    // `Authorization: Bearer ...` header)
     let token_generation_request = TokenGenerationRequest {
         integrity_token: None, // note the missing token
         aud: "relying-party.example.com".to_string(),
@@ -1766,7 +1750,6 @@ async fn test_developer_token_generation_e2e_success() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: Some(generated_client_token),
     };
     let body = serde_json::to_string(&token_generation_request).unwrap();
 
@@ -1777,6 +1760,10 @@ async fn test_developer_token_generation_e2e_success() {
                 .uri("/g")
                 .method(http::Method::POST)
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {generated_client_token}"),
+                )
                 .body(Body::from(body.clone()))
                 .unwrap(),
         )
@@ -1859,7 +1846,6 @@ async fn test_developer_token_generation_e2e_request_hash_mismatch() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: Some(generated_client_token),
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1871,6 +1857,10 @@ async fn test_developer_token_generation_e2e_request_hash_mismatch() {
                 .uri("/g")
                 .method(http::Method::POST)
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!("Bearer {generated_client_token}"),
+                )
                 .body(Body::from(body.clone()))
                 .unwrap(),
         )
@@ -1904,6 +1894,8 @@ async fn test_developer_token_generation_e2e_missing_token() {
 
     let api_router = get_api_router().await;
 
+    // note: no Authorization header is sent below, so the laissez-passer bypass
+    // does not kick in and Android verification requires `integrity_token`
     let token_generation_request = TokenGenerationRequest {
         integrity_token: None, // note the missing token
         aud: "relying-party.example.com".to_string(),
@@ -1913,8 +1905,6 @@ async fn test_developer_token_generation_e2e_missing_token() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        // note the missing developer_token
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();
@@ -1992,7 +1982,6 @@ async fn test_client_error_gets_logged_to_kinesis() {
         apple_initial_attestation: None,
         apple_public_key: None,
         apple_assertion: None,
-        developer_token: None,
     };
 
     let body = serde_json::to_string(&token_generation_request).unwrap();


### PR DESCRIPTION
This pull request refactors how developer (laissez-passer) tokens are handled in the attestation gateway. Instead of being passed in the request body, developer tokens must now be sent via the `Authorization: Bearer ...` HTTP header. This change improves security and aligns with standard authentication practices. The request and verification logic, as well as related integration tests, have been updated accordingly.