### PR TITLE
Use redis from handler arg

### DIFF
--- a/attestation-gateway/src/nonces/nonce_db.rs
+++ b/attestation-gateway/src/nonces/nonce_db.rs
@@ -21,14 +21,18 @@ pub enum NonceDbError {
 
 #[derive(Clone)]
 pub struct NonceDb {
-    redis: ConnectionManager,
+    // redis: ConnectionManager,
 }
 
 impl NonceDb {
-    #[must_use]
-    #[expect(clippy::missing_const_for_fn)] // `ConnectionManager` is not usable in `const`
-    pub fn new(redis: ConnectionManager) -> Self {
-        Self { redis }
+    // #[must_use]
+    // #[expect(clippy::missing_const_for_fn)] // `ConnectionManager` is not usable in `const`
+    // pub fn new(redis: ConnectionManager) -> Self {
+    //     Self { redis }
+    // }
+
+    pub fn new() -> Self {
+        Self {}
     }
 
     /// # Errors
@@ -36,6 +40,7 @@ impl NonceDb {
     /// When `token_details` cannot be serialized to JSON, or Redis rejects `SET`.
     pub async fn generate_nonce(
         &mut self,
+        redis: &mut ConnectionManager,
         token_details: &TokenDetails,
     ) -> Result<String, NonceDbError> {
         let mut nonce = [0; 16];
@@ -51,7 +56,7 @@ impl NonceDb {
             ))
             .conditional_set(ExistenceCheck::NX);
 
-        self.redis
+        redis
             .set_options::<String, String>(key, value, options)
             .await
             .map_err(NonceDbError::RedisError)?;
@@ -62,10 +67,13 @@ impl NonceDb {
     /// # Errors
     ///
     /// When Redis `GETDEL` fails, the value is missing, or JSON does not decode to [`TokenDetails`].
-    pub async fn consume_nonce(&mut self, nonce: &str) -> Result<TokenDetails, NonceDbError> {
+    pub async fn consume_nonce(
+        &mut self,
+        redis: &mut ConnectionManager,
+        nonce: &str,
+    ) -> Result<TokenDetails, NonceDbError> {
         let key = format!("nonce:{nonce}");
-        let value = self
-            .redis
+        let value = redis
             .get_del::<String>(key)
             .await
             .map_err(NonceDbError::RedisError)?

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -122,21 +122,24 @@ pub async fn handler(
         });
     }
 
-    let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
-        if matches!(e, NonceDbError::NonceNotFound) {
-            RequestError {
-                code: ErrorCode::BadRequest,
-                details: Some("Nonce not found".to_string()),
-            }
-        } else {
-            tracing::error!(error = ?e, "Error consuming token nonce");
+    let token_details = nonce_db
+        .consume_nonce(&mut redis, &request.nonce)
+        .await
+        .map_err(|e| {
+            if matches!(e, NonceDbError::NonceNotFound) {
+                RequestError {
+                    code: ErrorCode::BadRequest,
+                    details: Some("Nonce not found".to_string()),
+                }
+            } else {
+                tracing::error!(error = ?e, "Error consuming token nonce");
 
-            RequestError {
-                code: ErrorCode::InternalServerError,
-                details: Some("Error consuming token nonce".to_string()),
+                RequestError {
+                    code: ErrorCode::InternalServerError,
+                    details: Some("Error consuming token nonce".to_string()),
+                }
             }
-        }
-    })?;
+        })?;
 
     let challenge = format!("n={},av={}", request.nonce, request.app_version);
     let platform = request.bundle_identifier.platform();

--- a/attestation-gateway/src/routes/c.rs
+++ b/attestation-gateway/src/routes/c.rs
@@ -1,5 +1,6 @@
 use axum::{Extension, Json};
 use chrono::{DateTime, Utc};
+use redis::aio::ConnectionManager;
 use schemars::JsonSchema;
 
 use crate::nonces::{NonceDb, TokenDetails};
@@ -39,6 +40,7 @@ pub struct Response {
 /// ```
 pub async fn handler(
     Extension(mut nonce_db): Extension<NonceDb>,
+    Extension(mut redis): Extension<ConnectionManager>,
     Extension(global_config): Extension<GlobalConfig>,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
@@ -54,14 +56,17 @@ pub async fn handler(
     }
 
     let token_details = TokenDetails::from_aud(request.aud.clone());
-    let nonce = nonce_db.generate_nonce(&token_details).await.map_err(|e| {
-        tracing::error!(error = ?e, "Failed to generate nonce.");
+    let nonce = nonce_db
+        .generate_nonce(&mut redis, &token_details)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "Failed to generate nonce.");
 
-        RequestError {
-            code: ErrorCode::InternalServerError,
-            details: Some("Failed to generate nonce.".to_string()),
-        }
-    })?;
+            RequestError {
+                code: ErrorCode::InternalServerError,
+                details: Some("Failed to generate nonce.".to_string()),
+            }
+        })?;
 
     let device_key_expires_at =
         DateTime::<Utc>::from_timestamp(token_details.exp_max, 0).ok_or(RequestError {

--- a/attestation-gateway/src/server.rs
+++ b/attestation-gateway/src/server.rs
@@ -34,7 +34,7 @@ pub async fn start(
         ..Default::default()
     };
 
-    let nonce_db = NonceDb::new(redis.clone());
+    let nonce_db = NonceDb::new();
 
     let android_rate_limit_per_day = env::var("ANDROID_RATE_LIMIT_PER_DAY").ok().map(|v| {
         v.parse()

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -102,10 +102,8 @@ fn get_global_config_extension_with_pem(
     Extension(config)
 }
 
-fn extension_nonce_db(
-    redis: &redis::aio::ConnectionManager,
-) -> Extension<attestation_gateway::nonces::NonceDb> {
-    Extension(attestation_gateway::nonces::NonceDb::new(redis.clone()))
+fn extension_nonce_db() -> Extension<attestation_gateway::nonces::NonceDb> {
+    Extension(attestation_gateway::nonces::NonceDb::new())
 }
 
 async fn extension_android_attestation(
@@ -166,7 +164,7 @@ async fn get_api_router() -> aide::axum::ApiRouter {
         .layer(get_aws_config_extension().await)
         .layer(get_global_config_extension())
         .layer(extension_android_attestation(&redis_ext.0).await)
-        .layer(extension_nonce_db(&redis_ext.0))
+        .layer(extension_nonce_db())
         .layer(redis_ext)
         .layer(get_kinesis_extension().await)
 }
@@ -664,7 +662,7 @@ async fn test_server_error_is_properly_logged() {
             .layer(get_aws_config_extension().await)
             .layer(get_local_config_extension())
             .layer(extension_android_attestation(&redis_ext.0).await)
-            .layer(extension_nonce_db(&redis_ext.0))
+            .layer(extension_nonce_db())
             .layer(redis_ext)
             .layer(get_kinesis_extension().await)
     }
@@ -732,7 +730,7 @@ async fn test_apple_initial_attestation_e2e_success() {
         .layer(get_aws_config_extension().await)
         .layer(get_global_config_extension_with_pem(test_data.root_ca_pem))
         .layer(extension_android_attestation(&redis_ext.0).await)
-        .layer(extension_nonce_db(&redis_ext.0))
+        .layer(extension_nonce_db())
         .layer(redis_ext)
         .layer(get_kinesis_extension().await);
 


### PR DESCRIPTION
We are having nonsensical redis issues, the only visible difference is how redis is constructed comapred to `/g`. In this PR (that should be eventually reverted) I quickly hacked around passing redis via argument just check if errors goes away.