### PR TITLE
Switch redis client TLS to rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,15 +2629,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "itoa",
- "native-tls",
- "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
  "ryu",
- "sha1_smol",
  "socket2",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "url",
  "xxhash-rust",
@@ -3128,12 +3127,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/attestation-gateway/Cargo.toml
+++ b/attestation-gateway/Cargo.toml
@@ -36,7 +36,7 @@ metrics = "0.24.3"
 metrics-exporter-statsd = "0.9.0"
 openssl = { version = "0.10.75", features = ["vendored"] }
 rand = "0.10.0"
-redis = { version = "1.0.4", features = ["tokio-comp", "connection-manager", "tokio-native-tls-comp"] }
+redis = { version = "1.0.4", default-features = false, features = ["tokio-comp", "connection-manager", "tokio-rustls-comp"] }
 regex = "1.12.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 schemars = "0.8.22"


### PR DESCRIPTION
- Set `default-features = false` on the `redis` crate to avoid implicit OpenSSL TLS
- Use `tokio-rustls-comp` instead of `tokio-native-tls-comp` (aligned with api-router authorizer)
- Follow-up to Slack investigation of pipeline broken errors during `/c` and `/a` canary

Made with [Cursor](https://cursor.com)