### PR TITLE
Revert org.world.id.staging Android signing cert digest

### DIFF
--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -167,13 +167,14 @@ impl BundleIdentifier {
     #[must_use]
     pub const fn android_certificate_sha256_digest(&self) -> Option<&str> {
         match self {
-            Self::ComWorldcoin | Self::ComWorldcoinStaging | Self::OrgWorldIdStaging => {
+            Self::ComWorldcoin | Self::ComWorldcoinStaging => {
                 // cspell:disable-next-line
                 Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8")
             }
-            Self::ComWorldcoinDev | Self::OrgWorldId | Self::OrgWorldIdDev => {
-                Some("6a6a1474b5cbbb2b1aa57e0bc3")
-            }
+            Self::ComWorldcoinDev
+            | Self::OrgWorldId
+            | Self::OrgWorldIdStaging
+            | Self::OrgWorldIdDev => Some("6a6a1474b5cbbb2b1aa57e0bc3"),
             Self::OrgWorldcoinInsight
             | Self::OrgWorldcoinInsightStaging
             | Self::OrgWorldStagingId => None,
@@ -184,12 +185,13 @@ impl BundleIdentifier {
     #[must_use]
     pub const fn android_certificate_sha256_digest_base64(&self) -> Option<&'static str> {
         match self {
-            Self::ComWorldcoin | Self::ComWorldcoinStaging | Self::OrgWorldIdStaging => {
+            Self::ComWorldcoin | Self::ComWorldcoinStaging => {
                 Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=")
             }
-            Self::ComWorldcoinDev | Self::OrgWorldId | Self::OrgWorldIdDev => {
-                Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A=")
-            }
+            Self::ComWorldcoinDev
+            | Self::OrgWorldId
+            | Self::OrgWorldIdStaging
+            | Self::OrgWorldIdDev => Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A="),
             Self::OrgWorldcoinInsight
             | Self::OrgWorldcoinInsightStaging
             | Self::OrgWorldStagingId => None,


### PR DESCRIPTION
- Reverts #194 for `org.world.id.staging`: moves it back to the debug-keystore digest (`o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A=`) so `stagingDebug` local builds pass `POST /a`
- Release-signed staging (`worldcoin.jks`) will fail `POST /a` again after deploy — that was the tradeoff in #194

Made with [Cursor](https://cursor.com)