### PR TITLE
Set org.world.id Android signing cert digest to worldcoin.jks

### DIFF
--- a/attestation-gateway/src/android/integrity_token_data.rs
+++ b/attestation-gateway/src/android/integrity_token_data.rs
@@ -677,7 +677,8 @@ mod tests {
             app_integrity: AppIntegrity {
                 package_name: Some("org.world.id".to_string()),
                 version_code: Some("100".to_string()),
-                certificate_sha_256_digest: Some(vec!["6a6a1474b5cbbb2b1aa57e0bc3".to_string()]),
+                // cspell:disable-next-line
+                certificate_sha_256_digest: Some(vec!["nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8".to_string()]),
                 app_recognition_verdict: AppIntegrityVerdict::PlayRecognized,
             },
             account_details: AccountDetails {

--- a/attestation-gateway/src/android/integrity_token_data.rs
+++ b/attestation-gateway/src/android/integrity_token_data.rs
@@ -678,7 +678,9 @@ mod tests {
                 package_name: Some("org.world.id".to_string()),
                 version_code: Some("100".to_string()),
                 // cspell:disable-next-line
-                certificate_sha_256_digest: Some(vec!["nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8".to_string()]),
+                certificate_sha_256_digest: Some(vec![
+                    "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8".to_string(),
+                ]),
                 app_recognition_verdict: AppIntegrityVerdict::PlayRecognized,
             },
             account_details: AccountDetails {

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -167,11 +167,14 @@ impl BundleIdentifier {
     #[must_use]
     pub const fn android_certificate_sha256_digest(&self) -> Option<&str> {
         match self {
-            Self::ComWorldcoin | Self::ComWorldcoinStaging | Self::OrgWorldIdStaging => {
+            Self::ComWorldcoin
+            | Self::ComWorldcoinStaging
+            | Self::OrgWorldId
+            | Self::OrgWorldIdStaging => {
                 // cspell:disable-next-line
                 Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8")
             }
-            Self::ComWorldcoinDev | Self::OrgWorldId | Self::OrgWorldIdDev => {
+            Self::ComWorldcoinDev | Self::OrgWorldIdDev => {
                 Some("6a6a1474b5cbbb2b1aa57e0bc3")
             }
             Self::OrgWorldcoinInsight
@@ -184,10 +187,13 @@ impl BundleIdentifier {
     #[must_use]
     pub const fn android_certificate_sha256_digest_base64(&self) -> Option<&'static str> {
         match self {
-            Self::ComWorldcoin | Self::ComWorldcoinStaging | Self::OrgWorldIdStaging => {
+            Self::ComWorldcoin
+            | Self::ComWorldcoinStaging
+            | Self::OrgWorldId
+            | Self::OrgWorldIdStaging => {
                 Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=")
             }
-            Self::ComWorldcoinDev | Self::OrgWorldId | Self::OrgWorldIdDev => {
+            Self::ComWorldcoinDev | Self::OrgWorldIdDev => {
                 Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A=")
             }
             Self::OrgWorldcoinInsight
@@ -897,11 +903,12 @@ mod tests {
         let bundle = BundleIdentifier::OrgWorldId;
         assert_eq!(
             bundle.android_certificate_sha256_digest(),
-            Some("6a6a1474b5cbbb2b1aa57e0bc3")
+            // cspell:disable-next-line
+            Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8")
         );
         assert_eq!(
             bundle.android_certificate_sha256_digest_base64(),
-            Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A=")
+            Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=")
         );
     }
 

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -174,9 +174,7 @@ impl BundleIdentifier {
                 // cspell:disable-next-line
                 Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8")
             }
-            Self::ComWorldcoinDev | Self::OrgWorldIdDev => {
-                Some("6a6a1474b5cbbb2b1aa57e0bc3")
-            }
+            Self::ComWorldcoinDev | Self::OrgWorldIdDev => Some("6a6a1474b5cbbb2b1aa57e0bc3"),
             Self::OrgWorldcoinInsight
             | Self::OrgWorldcoinInsightStaging
             | Self::OrgWorldStagingId => None,
@@ -190,9 +188,7 @@ impl BundleIdentifier {
             Self::ComWorldcoin
             | Self::ComWorldcoinStaging
             | Self::OrgWorldId
-            | Self::OrgWorldIdStaging => {
-                Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=")
-            }
+            | Self::OrgWorldIdStaging => Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8="),
             Self::ComWorldcoinDev | Self::OrgWorldIdDev => {
                 Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A=")
             }


### PR DESCRIPTION
- Move `org.world.id` from debug/placeholder digest to `worldcoin.jks` digest (`nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=`) for both `POST /a` and `POST /g`
- Matches `com.worldcoin` and release-signed staging; unblocks prod World ID Android testing

Made with [Cursor](https://cursor.com)