### PR TITLE
Log request headers on /a analytics events

### DIFF
--- a/attestation-gateway/src/android/analytics_service.rs
+++ b/attestation-gateway/src/android/analytics_service.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{collections::HashMap, time::SystemTime};
 
 use aws_config::Region;
 use aws_sdk_kinesis::{Client as KinesisClient, primitives::Blob};
@@ -31,6 +31,8 @@ pub struct AndroidAttestationAnalyticsEvent {
     pub cert_chain: Option<CertChain>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub request_headers: HashMap<String, String>,
     pub timestamp: SystemTime,
 }
 
@@ -133,6 +135,7 @@ mod tests {
             bundle_identifier: BundleIdentifier::ComWorldcoinDev,
             cert_chain: None,
             error: None,
+            request_headers: HashMap::new(),
             timestamp: SystemTime::UNIX_EPOCH,
         };
 
@@ -153,7 +156,34 @@ mod tests {
         assert_eq!(json["bundle_identifier"], "com.worldcoin.dev");
         assert!(json.get("cert_chain").is_none());
         assert!(json.get("error").is_none());
+        assert!(json.get("request_headers").is_none());
         assert!(json.get("timestamp").is_some());
+    }
+
+    #[test]
+    fn serializes_event_with_request_headers() {
+        let event = AndroidAttestationAnalyticsEvent {
+            base64_cert_chain: vec!["cert".to_string()],
+            aud: "face".to_string(),
+            nonce: "nonce".to_string(),
+            app_version: "1.0.102".to_string(),
+            bundle_identifier: BundleIdentifier::OrgWorldIdStaging,
+            cert_chain: None,
+            error: None,
+            request_headers: HashMap::from([
+                ("header-1".to_string(), "value-1".to_string()),
+                ("header-2".to_string(), "value-2".to_string()),
+                ("header-3".to_string(), "value-3".to_string()),
+            ]),
+            timestamp: SystemTime::UNIX_EPOCH,
+        };
+
+        let (bytes, _) = AnalyticsService::serialize_event(&event).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(json["request_headers"]["header-1"], "value-1");
+        assert_eq!(json["request_headers"]["header-2"], "value-2");
+        assert_eq!(json["request_headers"]["header-3"], "value-3");
     }
 
     #[test]
@@ -166,6 +196,7 @@ mod tests {
             bundle_identifier: BundleIdentifier::ComWorldcoin,
             cert_chain: None,
             error: Some("invalid challenge".to_string()),
+            request_headers: HashMap::new(),
             timestamp: SystemTime::UNIX_EPOCH,
         };
 

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{collections::HashMap, time::SystemTime};
 
 use crate::{
     android::{
@@ -151,6 +151,7 @@ impl AndroidAttestationService {
         nonce: &String,
         app_version: &String,
         bundle_identifier: &BundleIdentifier,
+        request_headers: HashMap<String, String>,
     ) -> Result<AndroidAttestationOutput, AndroidAttestationError> {
         let build_result = self
             .cert_chain_builder
@@ -178,6 +179,7 @@ impl AndroidAttestationService {
                 bundle_identifier: bundle_identifier.clone(),
                 cert_chain,
                 error: verify_result.as_ref().err().map(ToString::to_string),
+                request_headers,
                 timestamp: SystemTime::now(),
             });
 

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -1,9 +1,6 @@
 use aws_config::SdkConfig;
 
-use axum::{
-    Extension, Json,
-    http::HeaderMap,
-};
+use axum::{Extension, Json, http::HeaderMap};
 use base64::{Engine, engine::general_purpose::STANDARD as Base64};
 use chrono::{DateTime, SubsecRound, Utc};
 use josekit::jwt::JwtPayload;

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -1,6 +1,9 @@
 use aws_config::SdkConfig;
 
-use axum::{Extension, Json};
+use axum::{
+    Extension, Json,
+    http::HeaderMap,
+};
 use base64::{Engine, engine::general_purpose::STANDARD as Base64};
 use chrono::{DateTime, SubsecRound, Utc};
 use josekit::jwt::JwtPayload;
@@ -20,6 +23,21 @@ use crate::{
     nonces::{NonceDb, NonceDbError},
     utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
 };
+
+fn headers_to_map(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::<String, String>::new();
+    for (name, value) in headers.iter() {
+        if let Ok(v) = value.to_str() {
+            map.entry(name.as_str().to_string())
+                .and_modify(|existing: &mut String| {
+                    existing.push_str(", ");
+                    existing.push_str(v);
+                })
+                .or_insert_with(|| v.to_string());
+        }
+    }
+    map
+}
 
 fn bad_request(details: impl Into<String>) -> RequestError {
     let details = details.into();
@@ -132,6 +150,7 @@ pub async fn handler(
     Extension(mut nonce_db): Extension<NonceDb>,
     Extension(mut android_attestation): Extension<AndroidAttestationService>,
     Extension(aws_config): Extension<SdkConfig>,
+    headers: HeaderMap,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
     let tracing_span = tracing::span!(tracing::Level::DEBUG, "a", endpoint = "/a");
@@ -187,6 +206,7 @@ pub async fn handler(
                     &request.nonce,
                     &request.app_version,
                     &request.bundle_identifier,
+                    headers_to_map(&headers),
                 )
                 .await;
 
@@ -358,5 +378,19 @@ mod tests {
             infer_platform(&request).unwrap_err().code,
             ErrorCode::BadRequest
         );
+    }
+
+    #[test]
+    fn headers_to_map_joins_duplicate_header_values() {
+        use axum::http::{HeaderMap, HeaderValue};
+
+        let mut headers = HeaderMap::new();
+        headers.insert("header-1", HeaderValue::from_static("value-1"));
+        headers.append("header-1", HeaderValue::from_static("value-1b"));
+        headers.insert("header-2", HeaderValue::from_static("value-2"));
+
+        let map = headers_to_map(&headers);
+        assert_eq!(map["header-1"], "value-1, value-1b");
+        assert_eq!(map["header-2"], "value-2");
     }
 }


### PR DESCRIPTION
- Capture all incoming request headers on `/a` and attach them to Android attestation Kinesis events as `request_headers`
- Omit the field when empty via `skip_serializing_if`
- Thread headers from the route handler through `AndroidAttestationService::verify()`

Made with [Cursor](https://cursor.com)