### PR TITLE
feat: authorize audiences through developer portal

### DIFF
--- a/attestation-gateway/src/audience_authorizer.rs
+++ b/attestation-gateway/src/audience_authorizer.rs
@@ -1,0 +1,321 @@
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use redis::aio::ConnectionManager;
+use thiserror::Error;
+
+use crate::utils::GlobalConfig;
+
+const CACHE_KEY_PREFIX: &str = "audience_authorization:v1:";
+const DEVELOPER_PORTAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Error)]
+pub enum AudienceAuthorizationError {
+    #[error("audience is not authorized")]
+    NotAuthorized,
+
+    #[error("developer portal base URL is not configured")]
+    MissingDeveloperPortalUrl,
+
+    #[error("developer portal request failed: {0}")]
+    DeveloperPortalRequest(#[from] reqwest::Error),
+
+    #[error("developer portal returned an unexpected status: {0}")]
+    DeveloperPortalUnexpectedStatus(reqwest::StatusCode),
+}
+
+#[derive(Clone)]
+pub struct AudienceAuthorizer {
+    static_audiences: Arc<HashSet<String>>,
+    developer_portal_base_url: Option<String>,
+    aud_authorization_cache_ttl_secs: u64,
+    http_client: reqwest::Client,
+    redis: ConnectionManager,
+}
+
+impl AudienceAuthorizer {
+    #[must_use]
+    pub fn from_config(redis: ConnectionManager, global_config: &GlobalConfig) -> Self {
+        Self {
+            static_audiences: Arc::new(global_config.aud_whitelist.iter().cloned().collect()),
+            developer_portal_base_url: global_config.developer_portal_base_url.clone(),
+            aud_authorization_cache_ttl_secs: global_config.aud_authorization_cache_ttl_secs,
+            http_client: build_http_client(),
+            redis,
+        }
+    }
+
+    /// Ensures an audience is authorized for nonce creation.
+    ///
+    /// Static allowlist entries are always authorized. Dynamic Developer Portal lookup is only
+    /// attempted for `app_...` and valid `rp_...` audiences.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the dynamic audience cannot be checked because the Developer Portal
+    /// request failed.
+    pub async fn ensure_authorized(&self, aud: &str) -> Result<(), AudienceAuthorizationError> {
+        if self.static_audiences.contains(aud) {
+            return Ok(());
+        }
+
+        if !is_dynamic_audience(aud) {
+            return Err(AudienceAuthorizationError::NotAuthorized);
+        }
+
+        match self.is_cached(aud).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(error = ?error, aud, "Failed to read audience authorization cache");
+            }
+        }
+
+        self.ensure_developer_portal_audience(aud).await?;
+        self.cache_authorized_audience(aud).await;
+
+        Ok(())
+    }
+
+    async fn ensure_developer_portal_audience(
+        &self,
+        aud: &str,
+    ) -> Result<(), AudienceAuthorizationError> {
+        let base_url = self
+            .developer_portal_base_url
+            .as_ref()
+            .ok_or(AudienceAuthorizationError::MissingDeveloperPortalUrl)?;
+        let url = format!(
+            "{}/api/v4/app-status/{}",
+            base_url.trim_end_matches('/'),
+            aud
+        );
+        let response = self.http_client.get(url).send().await?;
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        if status.is_client_error() {
+            return Err(AudienceAuthorizationError::NotAuthorized);
+        }
+
+        Err(AudienceAuthorizationError::DeveloperPortalUnexpectedStatus(
+            status,
+        ))
+    }
+
+    async fn is_cached(&self, aud: &str) -> Result<bool, redis::RedisError> {
+        let mut redis = self.redis.clone();
+        let cached_value = redis::cmd("GET")
+            .arg(cache_key(aud))
+            .query_async::<Option<String>>(&mut redis)
+            .await?;
+
+        Ok(cached_value.is_some())
+    }
+
+    async fn cache_authorized_audience(&self, aud: &str) {
+        let mut redis = self.redis.clone();
+        if let Err(error) = redis::cmd("SET")
+            .arg(cache_key(aud))
+            .arg("1")
+            .arg("EX")
+            .arg(self.aud_authorization_cache_ttl_secs)
+            .query_async::<()>(&mut redis)
+            .await
+        {
+            tracing::warn!(error = ?error, aud, "Failed to write audience authorization cache");
+        }
+    }
+}
+
+#[must_use]
+pub fn cache_key(aud: &str) -> String {
+    format!("{CACHE_KEY_PREFIX}{aud}")
+}
+
+fn is_dynamic_audience(aud: &str) -> bool {
+    aud.starts_with("app_") || is_valid_rp_id(aud)
+}
+
+fn is_valid_rp_id(rp_id: &str) -> bool {
+    if !rp_id.starts_with("rp_") {
+        return false;
+    }
+
+    let hex_part = &rp_id[3..];
+    hex_part.len() == 16 && hex_part.chars().all(|char| char.is_ascii_hexdigit())
+}
+
+fn build_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(DEVELOPER_PORTAL_REQUEST_TIMEOUT)
+        .build()
+        .expect("failed to build developer portal audience HTTP client")
+}
+
+#[cfg(test)]
+#[allow(clippy::significant_drop_tightening)]
+mod tests {
+    use std::{collections::HashSet, sync::Arc};
+
+    use mockito::Server;
+    use serial_test::serial;
+
+    use super::{AudienceAuthorizationError, AudienceAuthorizer, build_http_client, cache_key};
+
+    const APP_ID: &str = "app_123";
+    const RP_ID: &str = "rp_0123456789abcdef";
+    const APP_STATUS_RESPONSE: &str = r#"{"verified":false}"#;
+
+    async fn redis_client() -> redis::aio::ConnectionManager {
+        let client = redis::Client::open("redis://localhost").unwrap();
+        redis::cmd("FLUSHALL")
+            .exec(&mut client.clone().get_connection().unwrap())
+            .unwrap();
+
+        redis::aio::ConnectionManager::new(client).await.unwrap()
+    }
+
+    async fn authorizer(
+        static_audiences: &[&str],
+        developer_portal_base_url: Option<String>,
+    ) -> AudienceAuthorizer {
+        AudienceAuthorizer {
+            static_audiences: Arc::new(
+                static_audiences
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<HashSet<_>>(),
+            ),
+            developer_portal_base_url,
+            aud_authorization_cache_ttl_secs: 60 * 60,
+            http_client: build_http_client(),
+            redis: redis_client().await,
+        }
+    }
+
+    async fn assert_not_authorized(authorizer: &AudienceAuthorizer, aud: &str) {
+        let error = authorizer.ensure_authorized(aud).await.unwrap_err();
+        assert!(matches!(error, AudienceAuthorizationError::NotAuthorized));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn static_allowlist_authorizes_without_developer_portal_url() {
+        let authorizer = authorizer(&["face.worldcoin.org"], None).await;
+
+        authorizer
+            .ensure_authorized("face.worldcoin.org")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn unknown_non_static_domain_is_denied() {
+        let authorizer = authorizer(&["face.worldcoin.org"], None).await;
+
+        assert_not_authorized(&authorizer, "unknown.worldcoin.org").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn app_id_is_authorized_on_successful_developer_portal_response() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", format!("/api/v4/app-status/{APP_ID}").as_str())
+            .with_status(200)
+            .with_body(APP_STATUS_RESPONSE)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        authorizer.ensure_authorized(APP_ID).await.unwrap();
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn rp_id_is_authorized_on_successful_developer_portal_response() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", format!("/api/v4/app-status/{RP_ID}").as_str())
+            .with_status(200)
+            .with_body(APP_STATUS_RESPONSE)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        authorizer.ensure_authorized(RP_ID).await.unwrap();
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn successful_response_caches_requested_audience_only() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", format!("/api/v4/app-status/{APP_ID}").as_str())
+            .with_status(200)
+            .with_body(APP_STATUS_RESPONSE)
+            .expect(1)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        authorizer.ensure_authorized(APP_ID).await.unwrap();
+        authorizer.ensure_authorized(APP_ID).await.unwrap();
+
+        mock.assert_async().await;
+        assert!(authorizer.is_cached(APP_ID).await.unwrap());
+        assert!(!authorizer.is_cached(RP_ID).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn developer_portal_not_found_denies_and_does_not_cache() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", format!("/api/v4/app-status/{APP_ID}").as_str())
+            .with_status(404)
+            .expect(2)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        assert_not_authorized(&authorizer, APP_ID).await;
+        assert_not_authorized(&authorizer, APP_ID).await;
+
+        mock.assert_async().await;
+        assert!(!authorizer.is_cached(APP_ID).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn developer_portal_failure_fails_without_cache_and_allows_with_cache() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", format!("/api/v4/app-status/{APP_ID}").as_str())
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        assert!(authorizer.ensure_authorized(APP_ID).await.is_err());
+        authorizer.cache_authorized_audience(APP_ID).await;
+        authorizer.ensure_authorized(APP_ID).await.unwrap();
+
+        mock.assert_async().await;
+    }
+
+    #[test]
+    fn cache_key_has_v1_prefix() {
+        assert_eq!(
+            cache_key("app_123"),
+            "audience_authorization:v1:app_123".to_string()
+        );
+    }
+}

--- a/attestation-gateway/src/audience_authorizer.rs
+++ b/attestation-gateway/src/audience_authorizer.rs
@@ -1,12 +1,23 @@
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
-use redis::aio::ConnectionManager;
+use redis::{AsyncCommands, aio::ConnectionManager};
+use regex::Regex;
 use thiserror::Error;
 
 use crate::utils::GlobalConfig;
 
 const CACHE_KEY_PREFIX: &str = "audience_authorization:v1:";
 const DEVELOPER_PORTAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+// Starts with "app_" or "app_staging_" followed by 32 lowercase hex characters
+static APP_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^app(_staging)?_[a-f0-9]{32}$").expect("valid app ID regex"));
+// Starts with "rp_" followed by 16 hexadecimal characters (case-insensitive)
+static RP_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^rp_[0-9a-fA-F]{16}$").expect("valid RP ID regex"));
 
 #[derive(Debug, Error)]
 pub enum AudienceAuthorizationError {
@@ -58,22 +69,26 @@ impl AudienceAuthorizer {
             return Ok(());
         }
 
-        if !is_dynamic_audience(aud) {
+        if !is_rp_audience(aud) {
             return Err(AudienceAuthorizationError::NotAuthorized);
         }
 
         match self.is_cached(aud).await {
-            Ok(true) => return Ok(()),
-            Ok(false) => {}
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                self.ensure_developer_portal_audience(aud).await?;
+                self.cache_authorized_audience(aud).await;
+
+                Ok(())
+            }
             Err(error) => {
                 tracing::warn!(error = ?error, aud, "Failed to read audience authorization cache");
+                self.ensure_developer_portal_audience(aud).await?;
+                self.cache_authorized_audience(aud).await;
+
+                Ok(())
             }
         }
-
-        self.ensure_developer_portal_audience(aud).await?;
-        self.cache_authorized_audience(aud).await;
-
-        Ok(())
     }
 
     async fn ensure_developer_portal_audience(
@@ -107,24 +122,18 @@ impl AudienceAuthorizer {
 
     async fn is_cached(&self, aud: &str) -> Result<bool, redis::RedisError> {
         let mut redis = self.redis.clone();
-        let cached_value = redis::cmd("GET")
-            .arg(cache_key(aud))
-            .query_async::<Option<String>>(&mut redis)
-            .await?;
+        let cached_value: Option<String> = redis.get(cache_key(aud)).await?;
 
         Ok(cached_value.is_some())
     }
 
     async fn cache_authorized_audience(&self, aud: &str) {
         let mut redis = self.redis.clone();
-        if let Err(error) = redis::cmd("SET")
-            .arg(cache_key(aud))
-            .arg("1")
-            .arg("EX")
-            .arg(self.aud_authorization_cache_ttl_secs)
-            .query_async::<()>(&mut redis)
-            .await
-        {
+        let cache_result: redis::RedisResult<()> = redis
+            .set_ex(cache_key(aud), "1", self.aud_authorization_cache_ttl_secs)
+            .await;
+
+        if let Err(error) = cache_result {
             tracing::warn!(error = ?error, aud, "Failed to write audience authorization cache");
         }
     }
@@ -135,17 +144,16 @@ pub fn cache_key(aud: &str) -> String {
     format!("{CACHE_KEY_PREFIX}{aud}")
 }
 
-fn is_dynamic_audience(aud: &str) -> bool {
-    aud.starts_with("app_") || is_valid_rp_id(aud)
+fn is_rp_audience(aud: &str) -> bool {
+    is_app_id(aud) || is_rp_id(aud)
 }
 
-fn is_valid_rp_id(rp_id: &str) -> bool {
-    if !rp_id.starts_with("rp_") {
-        return false;
-    }
+fn is_app_id(app_id: &str) -> bool {
+    APP_ID_REGEX.is_match(app_id)
+}
 
-    let hex_part = &rp_id[3..];
-    hex_part.len() == 16 && hex_part.chars().all(|char| char.is_ascii_hexdigit())
+fn is_rp_id(rp_id: &str) -> bool {
+    RP_ID_REGEX.is_match(rp_id)
 }
 
 fn build_http_client() -> reqwest::Client {
@@ -165,8 +173,10 @@ mod tests {
 
     use super::{AudienceAuthorizationError, AudienceAuthorizer, build_http_client, cache_key};
 
-    const APP_ID: &str = "app_123";
+    const APP_ID: &str = "app_0123456789abcdef0123456789abcdef";
+    const STAGING_APP_ID: &str = "app_staging_0123456789abcdef0123456789abcdef";
     const RP_ID: &str = "rp_0123456789abcdef";
+    const MALFORMED_APP_ID: &str = "app_/../../../../public/v1/miniapps/prices";
     const APP_STATUS_RESPONSE: &str = r#"{"verified":false}"#;
 
     async fn redis_client() -> redis::aio::ConnectionManager {
@@ -222,6 +232,23 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn malformed_app_id_is_denied_without_developer_portal_call() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .expect(0)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        assert_not_authorized(&authorizer, MALFORMED_APP_ID).await;
+
+        mock.assert_async().await;
+        assert!(!authorizer.is_cached(MALFORMED_APP_ID).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn app_id_is_authorized_on_successful_developer_portal_response() {
         let mut server = Server::new_async().await;
         let mock = server
@@ -233,6 +260,25 @@ mod tests {
         let authorizer = authorizer(&[], Some(server.url())).await;
 
         authorizer.ensure_authorized(APP_ID).await.unwrap();
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn staging_app_id_is_authorized_on_successful_developer_portal_response() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock(
+                "GET",
+                format!("/api/v4/app-status/{STAGING_APP_ID}").as_str(),
+            )
+            .with_status(200)
+            .with_body(APP_STATUS_RESPONSE)
+            .create_async()
+            .await;
+        let authorizer = authorizer(&[], Some(server.url())).await;
+
+        authorizer.ensure_authorized(STAGING_APP_ID).await.unwrap();
         mock.assert_async().await;
     }
 
@@ -314,8 +360,8 @@ mod tests {
     #[test]
     fn cache_key_has_v1_prefix() {
         assert_eq!(
-            cache_key("app_123"),
-            "audience_authorization:v1:app_123".to_string()
+            cache_key(APP_ID),
+            "audience_authorization:v1:app_0123456789abcdef0123456789abcdef".to_string()
         );
     }
 }

--- a/attestation-gateway/src/lib.rs
+++ b/attestation-gateway/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod android;
 pub mod apple;
+pub mod audience_authorizer;
 pub mod developer;
 pub mod keys;
 pub mod kinesis;

--- a/attestation-gateway/src/main.rs
+++ b/attestation-gateway/src/main.rs
@@ -10,6 +10,7 @@ use std::{env, fmt};
 
 mod android;
 mod apple;
+mod audience_authorizer;
 mod developer;
 mod keys;
 mod kinesis;

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -242,16 +242,12 @@ pub async fn handler(
         .increment(1);
 
     let exp = match request.exp {
-        Some(exp) => {
-            if exp > token_details.exp_max {
-                return Err(bad_request("Exp is greater than token exp max"));
-            } else {
-                Ok(exp)
-            }
+        Some(exp) if exp > token_details.exp_max => {
+            return Err(bad_request("Exp is greater than token exp max"));
         }
-        None => Ok(token_details.exp_max),
-    }?;
-
+        Some(exp) => exp,
+        None => token_details.exp_max,
+    };
     let integrity_token = generate_integrity_token(
         &mut redis,
         &aws_config,

--- a/attestation-gateway/src/routes/c.rs
+++ b/attestation-gateway/src/routes/c.rs
@@ -2,8 +2,9 @@ use axum::{Extension, Json};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 
+use crate::audience_authorizer::{AudienceAuthorizationError, AudienceAuthorizer};
 use crate::nonces::{NonceDb, TokenDetails};
-use crate::utils::{ErrorCode, GlobalConfig, RequestError};
+use crate::utils::{ErrorCode, RequestError};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub struct Request {
@@ -39,21 +40,14 @@ pub struct Response {
 /// ```
 pub async fn handler(
     Extension(mut nonce_db): Extension<NonceDb>,
-    Extension(global_config): Extension<GlobalConfig>,
+    Extension(audience_authorizer): Extension<AudienceAuthorizer>,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
     let tracing_span =
         tracing::span!(tracing::Level::DEBUG, "c", aud = %request.aud, endpoint = "/c");
     let _enter = tracing_span.enter();
 
-    if !global_config.aud_whitelist.contains(&request.aud) {
-        tracing::error!(aud = %request.aud, "This audience is currently unavailable.");
-
-        return Err(RequestError {
-            code: ErrorCode::BadRequest,
-            details: Some("This audience is currently unavailable.".to_string()),
-        });
-    }
+    audience_authorizer.ensure_authorized(&request.aud).await?;
 
     let token_details = TokenDetails::from_aud(request.aud.clone());
     let nonce = nonce_db.generate_nonce(&token_details).await.map_err(|e| {
@@ -79,4 +73,23 @@ pub async fn handler(
         token_exp_max: token_details.exp_max,
         device_key_expires_at,
     }))
+}
+
+impl From<AudienceAuthorizationError> for RequestError {
+    fn from(error: AudienceAuthorizationError) -> Self {
+        match error {
+            AudienceAuthorizationError::NotAuthorized => Self {
+                code: ErrorCode::BadRequest,
+                details: Some("This audience is currently unavailable.".to_owned()),
+            },
+            error => {
+                tracing::error!(error = ?error, "Failed to authorize audience");
+
+                Self {
+                    code: ErrorCode::InternalServerError,
+                    details: Some("Failed to authorize audience.".to_owned()),
+                }
+            }
+        }
+    }
 }

--- a/attestation-gateway/src/server.rs
+++ b/attestation-gateway/src/server.rs
@@ -1,6 +1,8 @@
 use std::{env, net::SocketAddr, time::Duration};
 
-use crate::{android::AndroidAttestationService, nonces::NonceDb};
+use crate::{
+    android::AndroidAttestationService, audience_authorizer::AudienceAuthorizer, nonces::NonceDb,
+};
 use aide::openapi::{Info, OpenApi};
 use aws_sdk_kinesis::Client as KinesisClient;
 use axum::Extension;
@@ -35,6 +37,7 @@ pub async fn start(
     };
 
     let nonce_db = NonceDb::new(redis.clone());
+    let audience_authorizer = AudienceAuthorizer::from_config(redis.clone(), &global_config);
 
     let android_rate_limit_per_day = env::var("ANDROID_RATE_LIMIT_PER_DAY").ok().map(|v| {
         v.parse()
@@ -58,6 +61,7 @@ pub async fn start(
     let app = routes::handler()
         .finish_api(&mut openapi)
         .layer(Extension(nonce_db))
+        .layer(Extension(audience_authorizer))
         .layer(Extension(redis))
         .layer(Extension(openapi))
         .layer(Extension(aws_config))

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -23,6 +23,8 @@ pub struct GlobalConfig {
     pub apple_root_ca_pem: Vec<u8>,
     pub aud_whitelist: Vec<String>,
     pub jwt_issuer: String,
+    pub developer_portal_base_url: Option<String>,
+    pub aud_authorization_cache_ttl_secs: u64,
 }
 
 impl GlobalConfig {
@@ -67,6 +69,14 @@ impl GlobalConfig {
         let jwt_issuer =
             env::var("JWT_ISSUER").unwrap_or_else(|_| "attestation.worldcoin.org".to_string());
 
+        let developer_portal_base_url = env::var("DEVELOPER_PORTAL_BASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+
+        let aud_authorization_cache_ttl_secs = env::var("AUD_AUTHORIZATION_CACHE_TTL_SECS")
+            .map_or(Ok(60 * 60), |value| value.parse::<u64>())
+            .expect("AUD_AUTHORIZATION_CACHE_TTL_SECS must be a valid u64");
+
         tracing::info!(
             "Running with enabled bundle identifiers: {:?}",
             enabled_bundle_identifiers
@@ -83,6 +93,8 @@ impl GlobalConfig {
             apple_root_ca_pem: include_bytes!("apple/apple_app_attestation_root_ca.pem").to_vec(),
             aud_whitelist,
             jwt_issuer,
+            developer_portal_base_url,
+            aud_authorization_cache_ttl_secs,
         }
     }
 }

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -98,6 +98,8 @@ fn get_global_config_extension_with_pem(
         apple_root_ca_pem,
         aud_whitelist: vec!["relying-party.example.com".to_string()],
         jwt_issuer: "attestation.worldcoin.org".to_string(),
+        developer_portal_base_url: None,
+        aud_authorization_cache_ttl_secs: 60 * 60,
     };
     Extension(config)
 }
@@ -106,6 +108,18 @@ fn extension_nonce_db(
     redis: &redis::aio::ConnectionManager,
 ) -> Extension<attestation_gateway::nonces::NonceDb> {
     Extension(attestation_gateway::nonces::NonceDb::new(redis.clone()))
+}
+
+fn extension_audience_authorizer(
+    redis: &redis::aio::ConnectionManager,
+    global_config: &attestation_gateway::utils::GlobalConfig,
+) -> Extension<attestation_gateway::audience_authorizer::AudienceAuthorizer> {
+    Extension(
+        attestation_gateway::audience_authorizer::AudienceAuthorizer::from_config(
+            redis.clone(),
+            global_config,
+        ),
+    )
 }
 
 async fn extension_android_attestation(
@@ -162,13 +176,34 @@ async fn get_kinesis_extension() -> Extension<aws_sdk_kinesis::Client> {
 
 async fn get_api_router() -> aide::axum::ApiRouter {
     let redis_ext = get_redis_extension().await;
+    let global_config_ext = get_global_config_extension();
     attestation_gateway::routes::handler()
         .layer(get_aws_config_extension().await)
-        .layer(get_global_config_extension())
+        .layer(global_config_ext.clone())
         .layer(extension_android_attestation(&redis_ext.0).await)
+        .layer(extension_audience_authorizer(
+            &redis_ext.0,
+            &global_config_ext.0,
+        ))
         .layer(extension_nonce_db(&redis_ext.0))
         .layer(redis_ext)
         .layer(get_kinesis_extension().await)
+}
+
+async fn get_challenge_router() -> (aide::axum::ApiRouter, redis::aio::ConnectionManager) {
+    let redis_ext = get_redis_extension().await;
+    let redis = redis_ext.0.clone();
+    let global_config_ext = get_global_config_extension();
+    let api_router = attestation_gateway::routes::handler()
+        .layer(global_config_ext.clone())
+        .layer(extension_audience_authorizer(
+            &redis_ext.0,
+            &global_config_ext.0,
+        ))
+        .layer(extension_nonce_db(&redis_ext.0))
+        .layer(redis_ext);
+
+    (api_router, redis)
 }
 
 /// Generates a valid Android integrity token (simulating what Play Store would generate)
@@ -256,6 +291,69 @@ gyCLKWWNJZlQ/NBTSekcw1M7xn2Z45Mdres5E7dzazXiC75Zzl4p2+gf
 
     jwe
 }
+
+// SECTION ------------------ challenge tests ------------------
+
+#[tokio::test]
+#[serial]
+async fn test_challenge_static_allowlist_succeeds() {
+    let (api_router, _redis) = get_challenge_router().await;
+
+    let response = api_router
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/c")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "aud": "relying-party.example.com" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response_body = response.collect().await.unwrap().to_bytes();
+    let response_json: Value = serde_json::from_slice(&response_body).unwrap();
+    assert!(
+        response_json["nonce"]
+            .as_str()
+            .is_some_and(|nonce| !nonce.is_empty())
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_challenge_unauthorized_audience_does_not_create_nonce() {
+    let (api_router, mut redis) = get_challenge_router().await;
+
+    let response = api_router
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/c")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "aud": "face.worldcoin.org" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let nonce_keys = redis::cmd("KEYS")
+        .arg("nonce:*")
+        .query_async::<Vec<String>>(&mut redis)
+        .await
+        .unwrap();
+    assert!(nonce_keys.is_empty());
+}
+
+// !SECTION ------------------ challenge tests ------------------
 
 // SECTION ------------------ android tests ------------------
 
@@ -654,16 +752,23 @@ async fn test_server_error_is_properly_logged() {
                 .to_vec(),
             aud_whitelist: vec!["relying-party.example.com".to_string()],
             jwt_issuer: "attestation.worldcoin.org".to_string(),
+            developer_portal_base_url: None,
+            aud_authorization_cache_ttl_secs: 60 * 60,
         };
         Extension(config)
     }
 
     async fn get_local_api_router() -> aide::axum::ApiRouter {
         let redis_ext = get_redis_extension().await;
+        let global_config_ext = get_local_config_extension();
         attestation_gateway::routes::handler()
             .layer(get_aws_config_extension().await)
-            .layer(get_local_config_extension())
+            .layer(global_config_ext.clone())
             .layer(extension_android_attestation(&redis_ext.0).await)
+            .layer(extension_audience_authorizer(
+                &redis_ext.0,
+                &global_config_ext.0,
+            ))
             .layer(extension_nonce_db(&redis_ext.0))
             .layer(redis_ext)
             .layer(get_kinesis_extension().await)
@@ -730,10 +835,15 @@ async fn test_apple_initial_attestation_e2e_success() {
         apple::test_helpers::build_test_attestation(app_id, request_hash, "appattestdevelop");
 
     let redis_ext = get_redis_extension().await;
+    let global_config_ext = get_global_config_extension_with_pem(test_data.root_ca_pem);
     let api_router = attestation_gateway::routes::handler()
         .layer(get_aws_config_extension().await)
-        .layer(get_global_config_extension_with_pem(test_data.root_ca_pem))
+        .layer(global_config_ext.clone())
         .layer(extension_android_attestation(&redis_ext.0).await)
+        .layer(extension_audience_authorizer(
+            &redis_ext.0,
+            &global_config_ext.0,
+        ))
         .layer(extension_nonce_db(&redis_ext.0))
         .layer(redis_ext)
         .layer(get_kinesis_extension().await);


### PR DESCRIPTION
This PR adds support for dynamic audiences by looking up `rp_id/app_id` in the dev portal. 

Created a new `audience_authoriser` module:
- Looks up the allowlist we had before
- If the `aud` looks like an `app_id/rp_id` then we lookup dev portal to see if it's registered there
- Otherwise we return error 