### PR TITLE
[MCORE-1404] Read device_model from /a body into analytics events

### DIFF
--- a/attestation-gateway/src/android/analytics_service.rs
+++ b/attestation-gateway/src/android/analytics_service.rs
@@ -33,6 +33,8 @@ pub struct AndroidAttestationAnalyticsEvent {
     pub error: Option<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub request_headers: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_model: Option<String>,
     pub timestamp: SystemTime,
 }
 
@@ -136,6 +138,7 @@ mod tests {
             cert_chain: None,
             error: None,
             request_headers: HashMap::new(),
+            device_model: None,
             timestamp: SystemTime::UNIX_EPOCH,
         };
 
@@ -157,6 +160,7 @@ mod tests {
         assert!(json.get("cert_chain").is_none());
         assert!(json.get("error").is_none());
         assert!(json.get("request_headers").is_none());
+        assert!(json.get("device_model").is_none());
         assert!(json.get("timestamp").is_some());
     }
 
@@ -175,6 +179,7 @@ mod tests {
                 ("header-2".to_string(), "value-2".to_string()),
                 ("header-3".to_string(), "value-3".to_string()),
             ]),
+            device_model: None,
             timestamp: SystemTime::UNIX_EPOCH,
         };
 
@@ -184,6 +189,27 @@ mod tests {
         assert_eq!(json["request_headers"]["header-1"], "value-1");
         assert_eq!(json["request_headers"]["header-2"], "value-2");
         assert_eq!(json["request_headers"]["header-3"], "value-3");
+    }
+
+    #[test]
+    fn serializes_event_with_device_model() {
+        let event = AndroidAttestationAnalyticsEvent {
+            base64_cert_chain: vec!["cert".to_string()],
+            aud: "face".to_string(),
+            nonce: "nonce".to_string(),
+            app_version: "1.0.102".to_string(),
+            bundle_identifier: BundleIdentifier::OrgWorldIdStaging,
+            cert_chain: None,
+            error: None,
+            request_headers: HashMap::new(),
+            device_model: Some("Pixel 8 Pro".to_string()),
+            timestamp: SystemTime::UNIX_EPOCH,
+        };
+
+        let (bytes, _) = AnalyticsService::serialize_event(&event).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(json["device_model"], "Pixel 8 Pro");
     }
 
     #[test]
@@ -197,6 +223,7 @@ mod tests {
             cert_chain: None,
             error: Some("invalid challenge".to_string()),
             request_headers: HashMap::new(),
+            device_model: None,
             timestamp: SystemTime::UNIX_EPOCH,
         };
 

--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -152,6 +152,7 @@ impl AndroidAttestationService {
         app_version: &String,
         bundle_identifier: &BundleIdentifier,
         request_headers: HashMap<String, String>,
+        device_model: Option<String>,
     ) -> Result<AndroidAttestationOutput, AndroidAttestationError> {
         let build_result = self
             .cert_chain_builder
@@ -180,6 +181,7 @@ impl AndroidAttestationService {
                 cert_chain,
                 error: verify_result.as_ref().err().map(ToString::to_string),
                 request_headers,
+                device_model,
                 timestamp: SystemTime::now(),
             });
 

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -53,6 +53,7 @@ pub struct Request {
     pub bundle_identifier: BundleIdentifier,
     pub apple_attestation: Option<String>,
     pub android_attestation: Option<Vec<String>>,
+    pub device_model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
@@ -204,6 +205,7 @@ pub async fn handler(
                     &request.app_version,
                     &request.bundle_identifier,
                     headers_to_map(&headers),
+                    request.device_model.clone(),
                 )
                 .await;
 
@@ -345,6 +347,7 @@ mod tests {
             bundle_identifier: BundleIdentifier::OrgWorldId,
             apple_attestation: None,
             android_attestation: None,
+            device_model: None,
         }
     }
 

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -1037,6 +1037,8 @@ mod tests {
             apple_root_ca_pem: Vec::new(),
             aud_whitelist: Vec::new(),
             jwt_issuer: String::new(),
+            developer_portal_base_url: None,
+            aud_authorization_cache_ttl_secs: 0,
         }
     }
 


### PR DESCRIPTION
## Summary
- Read the `device_model` field from the POST `/a` request body and forward it to the Kinesis `AndroidAttestationAnalyticsEvent`, so attested-key analytics events can be correlated with the device model.
- Mirrors how #197 threaded `request_headers`: add the field to the `/a` `Request` body struct, thread it through `AndroidAttestationService::verify`, and serialize it on the analytics event with `skip_serializing_if = "Option::is_none"`.

## Why
The Android app started sending `device_model` in the `/a` request body in worldcoin/wld-android#7921 (MCORE-1342), but the gateway silently dropped it: the `Request` struct did not deserialize the field and the analytics event did not carry it. This is the gateway-side follow-up that the app PR called out.

## Changes
- `routes/a.rs`: add `device_model: Option<String>` to `Request`; pass `request.device_model.clone()` into `verify`.
- `android/android_attestation_service.rs`: add `device_model: Option<String>` parameter to `verify`, set it on the event.
- `android/analytics_service.rs`: add `device_model: Option<String>` to `AndroidAttestationAnalyticsEvent` (`skip_serializing_if = "Option::is_none"`); new `serializes_event_with_device_model` test plus updated existing tests.
- `utils.rs` (test-only): fix a pre-existing `cargo test --all` build break introduced by #198 by adding the missing `developer_portal_base_url` and `aud_authorization_cache_ttl_secs` fields to the `config_with_android_keys` test helper.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy`
- [x] `cargo test --lib` for `analytics_service` and `routes::a` (new + existing tests pass). The remaining `--all` failures locally are AWS/network-dependent (`kms_jws`, `keys`, `audience_authorizer`) and unrelated to this change.

Closes MCORE-1404.