### PR TITLE
CORPLAT-922: allow Apple attestation for org.world.sandbox.id

### DIFF
--- a/attestation-gateway/src/apple/mod.rs
+++ b/attestation-gateway/src/apple/mod.rs
@@ -183,6 +183,11 @@ impl AAGUID {
                 // production environment (e.g. through TestFlight distribution)
                 Ok([Self::AppAttest, Self::AppAttestDevelop].to_vec())
             }
+            BundleIdentifier::OrgWorldcoinInsightSandbox | BundleIdentifier::OrgWorldSandboxId => {
+                // Sandbox app can be operating in either the development environment (e.g. local development) or
+                // production environment (e.g. through TestFlight distribution)
+                Ok([Self::AppAttest, Self::AppAttestDevelop].to_vec())
+            }
             _ => eyre::bail!("Invalid bundle identifier for Apple verification."),
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #203. Adds the iOS sandbox bundles to the Apple App Attest AAGUID allowlist so they can complete Apple attestation, mirroring the existing staging arm.

The subtle part is the `org.world.*` naming:
- `OrgWorldStagingId` = `org.world.staging.id` → iOS bundle (has an `apple_app_id`)
- `OrgWorldIdStaging` = `org.world.id.staging` → Android bundle (Play Integrity)

The sandbox arm now uses the iOS variant `OrgWorldSandboxId` (`org.world.sandbox.id`) alongside `OrgWorldcoinInsightSandbox`. Both allow `AppAttest` and `AppAttestDevelop`, consistent with staging. Without this, `org.world.sandbox.id` would fall through to the `_ => bail!` arm and fail Apple attestation.

The Android sandbox bundles (`com.worldcoin.sandbox`, `org.world.id.sandbox`) are intentionally not here — they go through Play Integrity and are already covered by the exhaustive matches in `utils.rs`.

## Test plan

- [x] `cargo check --all-targets` passes
- [ ] Confirm the sandbox Apple app IDs (`35RXKB6738.org.world.sandbox.id`, `35RXKB6738.org.worldcoin.insight.sandbox`) are correct
- [ ] Add sandbox bundles to `ENABLED_BUNDLE_IDENTIFIERS` in the target environment so they're accepted at runtime

Made with [Cursor](https://cursor.com)