### PR TITLE
feat: source output token issuer from JWT_ISSUER env var

### DIFF
--- a/attestation-gateway/src/kms_jws/tests.rs
+++ b/attestation-gateway/src/kms_jws/tests.rs
@@ -87,6 +87,7 @@ async fn test_generate_output_token() {
     let aws_config = get_aws_config().await;
 
     let output_token_payload = OutputTokenPayload {
+        issuer: "attestation.worldcoin.org".to_string(),
         aud: "example.worldcoin.org".to_string(),
         request_hash: "a_sample_request_hash".to_string(),
         bundle_identifier: BundleIdentifier::ComWorldcoinStaging,

--- a/attestation-gateway/src/routes/generate_token.rs
+++ b/attestation-gateway/src/routes/generate_token.rs
@@ -374,6 +374,7 @@ async fn process_and_finalize_report(
     }
     // Generate output attestation token
     let output_token_payload = OutputTokenPayload {
+        issuer: global_config.jwt_issuer.clone(),
         aud,
         bundle_identifier: report.bundle_identifier.clone(),
         request_hash: request_hash.clone(),

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -769,6 +769,7 @@ impl DataReport {
 
 #[derive(Debug)]
 pub struct OutputTokenPayload {
+    pub issuer: String,
     pub aud: String,
     pub request_hash: String,
     pub bundle_identifier: BundleIdentifier,
@@ -809,7 +810,7 @@ impl OutputTokenPayload {
     pub fn generate(&self) -> Result<JwtPayload, RequestError> {
         let mut payload = JwtPayload::new();
         payload.set_issued_at(&SystemTime::now());
-        payload.set_issuer("attestation.worldcoin.org");
+        payload.set_issuer(&self.issuer);
         payload.set_expires_at(&(SystemTime::now() + OUTPUT_TOKEN_EXPIRATION));
 
         // Claims
@@ -896,6 +897,7 @@ mod tests {
         let now = SystemTime::now();
 
         let payload = OutputTokenPayload {
+            issuer: "attestation.worldcoin.org".to_string(),
             aud: "my-aud.com".to_string(),
             request_hash: "this_is_not_a_hash_with_enough_entropy".to_string(),
             bundle_identifier: BundleIdentifier::ComWorldcoinStaging,


### PR DESCRIPTION
## Summary
- The output attestation token issuer was previously hardcoded to `attestation.worldcoin.org` in `OutputTokenPayload::generate`.
- This change adds an `issuer` field to `OutputTokenPayload`, populated from `global_config.jwt_issuer`, which is read from the `JWT_ISSUER` environment variable (defaulting to `attestation.worldcoin.org` when unset).
- As a result, the token issuer is now configurable per environment instead of being hardcoded, matching how the integrity token already sources its issuer.

## Changes
- `utils.rs`: add `pub issuer: String` to `OutputTokenPayload`; `generate` now uses `self.issuer` instead of the hardcoded string.
- `routes/generate_token.rs`: set `issuer: global_config.jwt_issuer.clone()` when building the payload.
- Tests (`utils.rs`, `kms_jws/tests.rs`): set the `issuer` field explicitly.

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [ ] Verify a deployed environment with a custom `JWT_ISSUER` produces tokens with the expected `iss` claim.

Made with [Cursor](https://cursor.com)