### PR TITLE
fix: remove debug builds allowance for iOS

### DIFF
--- a/attestation-gateway/src/apple/mod.rs
+++ b/attestation-gateway/src/apple/mod.rs
@@ -175,8 +175,7 @@ impl AAGUID {
     ) -> eyre::Result<Vec<Self>> {
         match bundle_identifier {
             BundleIdentifier::OrgWorldcoinInsight | BundleIdentifier::OrgWorldId => {
-                // REVIEW: Temporarily allowing local development for production app. Remove after April 10, 2025.
-                Ok([Self::AppAttest, Self::AppAttestDevelop].to_vec())
+                Ok([Self::AppAttest].to_vec())
             }
             BundleIdentifier::OrgWorldcoinInsightStaging | BundleIdentifier::OrgWorldStagingId => {
                 // Staging app can be operating in either the development environment (e.g. local development) or


### PR DESCRIPTION
With explicit mechanisms for local development now, allowing debug certificates for prod apps is no longer required.