### PR TITLE
Return distinct error codes for /a attestation failures

### DIFF
--- a/attestation-gateway/src/android/mod.rs
+++ b/attestation-gateway/src/android/mod.rs
@@ -17,7 +17,7 @@ mod root_cert;
 mod serde_hex;
 mod session_cert;
 
-pub use android_attestation_service::AndroidAttestationService;
+pub use android_attestation_service::{AndroidAttestationError, AndroidAttestationService};
 
 #[allow(unused_imports)]
 pub use cert_chain_builder::CertChainBuilder;

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -15,7 +15,7 @@ use redis::aio::ConnectionManager;
 use schemars::JsonSchema;
 
 use crate::{
-    android::AndroidAttestationService,
+    android::{AndroidAttestationError, AndroidAttestationService},
     apple, keys, kms_jws,
     nonces::{NonceDb, NonceDbError},
     utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
@@ -119,6 +119,27 @@ impl IntegrityTokenPayload {
     }
 }
 
+fn map_android_attestation_error(e: &AndroidAttestationError) -> RequestError {
+    metrics::counter!("attestation_gateway.android_error", "reason" => e.reason_tag()).increment(1);
+
+    if e.is_internal_error() {
+        tracing::error!(error = ?e, "Error validating Android attestation");
+
+        RequestError {
+            code: ErrorCode::InternalServerError,
+            details: None,
+        }
+    } else {
+        // The precise verify failure stays server-side; the client gets only the coarse
+        // default message so rejection reasons don't aid attestation probing.
+        tracing::error!(endpoint = "/a", message = %e);
+        RequestError {
+            code: ErrorCode::AttestationRejected,
+            details: None,
+        }
+    }
+}
+
 fn infer_platform(request: &Request) -> Result<Platform, RequestError> {
     let has_android = request.android_attestation.is_some();
     let has_apple = request.apple_attestation.is_some();
@@ -165,7 +186,11 @@ pub async fn handler(
 
     let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
         if matches!(e, NonceDbError::NonceNotFound) {
-            bad_request("Nonce not found")
+            tracing::error!(endpoint = "/a", message = "Nonce not found");
+            RequestError {
+                code: ErrorCode::NonceNotFound,
+                details: None,
+            }
         } else {
             tracing::error!(error = ?e, "Error consuming token nonce");
 
@@ -209,24 +234,8 @@ pub async fn handler(
                 )
                 .await;
 
-            let attestation_output = match attestation_result {
-                Ok(attestation_output) => Ok(attestation_output),
-                Err(e) => {
-                    metrics::counter!("attestation_gateway.android_error",  "reason" => e.reason_tag())
-                        .increment(1);
-
-                    if e.is_internal_error() {
-                        tracing::error!(error = ?e, "Error validating Android attestation");
-
-                        Err(RequestError {
-                            code: ErrorCode::InternalServerError,
-                            details: None,
-                        })
-                    } else {
-                        Err(bad_request(e.to_string()))
-                    }
-                }
-            }?;
+            let attestation_output =
+                attestation_result.map_err(|e| map_android_attestation_error(&e))?;
 
             if let Some(os_patch_level_delta) = attestation_output.os_patch_level_delta {
                 metrics::gauge!("attestation_gateway.android_os_patch_level_delta")

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -18,7 +18,7 @@ use crate::{
     android::{AndroidAttestationError, AndroidAttestationService},
     apple, keys, kms_jws,
     nonces::{NonceDb, NonceDbError},
-    utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
+    utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError, client_session_id},
 };
 
 fn headers_to_map(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
@@ -119,7 +119,7 @@ impl IntegrityTokenPayload {
     }
 }
 
-fn map_android_attestation_error(e: &AndroidAttestationError) -> RequestError {
+fn map_android_attestation_error(e: &AndroidAttestationError, session_id: &str) -> RequestError {
     metrics::counter!("attestation_gateway.android_error", "reason" => e.reason_tag()).increment(1);
 
     if e.is_internal_error() {
@@ -132,7 +132,7 @@ fn map_android_attestation_error(e: &AndroidAttestationError) -> RequestError {
     } else {
         // The precise verify failure stays server-side; the client gets only the coarse
         // default message so rejection reasons don't aid attestation probing.
-        tracing::error!(endpoint = "/a", message = %e);
+        tracing::error!(endpoint = "/a", session_id = %session_id, message = %e);
         RequestError {
             code: ErrorCode::AttestationRejected,
             details: None,
@@ -172,7 +172,9 @@ pub async fn handler(
     headers: HeaderMap,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
-    let tracing_span = tracing::span!(tracing::Level::DEBUG, "a", endpoint = "/a");
+    let session_id = client_session_id(&headers);
+    let tracing_span =
+        tracing::span!(tracing::Level::DEBUG, "a", endpoint = "/a", session_id = %session_id);
     let _enter = tracing_span.enter();
 
     if !global_config
@@ -186,7 +188,7 @@ pub async fn handler(
 
     let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
         if matches!(e, NonceDbError::NonceNotFound) {
-            tracing::error!(endpoint = "/a", message = "Nonce not found");
+            tracing::error!(endpoint = "/a", session_id = %session_id, message = "Nonce not found");
             RequestError {
                 code: ErrorCode::NonceNotFound,
                 details: None,
@@ -235,7 +237,7 @@ pub async fn handler(
                 .await;
 
             let attestation_output =
-                attestation_result.map_err(|e| map_android_attestation_error(&e))?;
+                attestation_result.map_err(|e| map_android_attestation_error(&e, session_id))?;
 
             if let Some(os_patch_level_delta) = attestation_output.os_patch_level_delta {
                 metrics::gauge!("attestation_gateway.android_os_patch_level_delta")

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -132,7 +132,7 @@ fn map_android_attestation_error(e: &AndroidAttestationError, session_id: &str) 
     } else {
         // The precise verify failure stays server-side; the client gets only the coarse
         // default message so rejection reasons don't aid attestation probing.
-        tracing::error!(endpoint = "/a", session_id = %session_id, message = %e);
+        tracing::warn!(endpoint = "/a", session_id = %session_id, message = %e);
         RequestError {
             code: ErrorCode::AttestationRejected,
             details: None,
@@ -188,7 +188,7 @@ pub async fn handler(
 
     let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
         if matches!(e, NonceDbError::NonceNotFound) {
-            tracing::error!(endpoint = "/a", session_id = %session_id, message = "Nonce not found");
+            tracing::warn!(endpoint = "/a", session_id = %session_id, message = "Nonce not found");
             RequestError {
                 code: ErrorCode::NonceNotFound,
                 details: None,

--- a/attestation-gateway/src/routes/c.rs
+++ b/attestation-gateway/src/routes/c.rs
@@ -1,10 +1,10 @@
-use axum::{Extension, Json};
+use axum::{Extension, Json, http::HeaderMap};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 
 use crate::audience_authorizer::{AudienceAuthorizationError, AudienceAuthorizer};
 use crate::nonces::{NonceDb, TokenDetails};
-use crate::utils::{ErrorCode, RequestError};
+use crate::utils::{ErrorCode, RequestError, client_session_id};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub struct Request {
@@ -41,13 +41,33 @@ pub struct Response {
 pub async fn handler(
     Extension(mut nonce_db): Extension<NonceDb>,
     Extension(audience_authorizer): Extension<AudienceAuthorizer>,
+    headers: HeaderMap,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
-    let tracing_span =
-        tracing::span!(tracing::Level::DEBUG, "c", aud = %request.aud, endpoint = "/c");
+    let session_id = client_session_id(&headers);
+    let tracing_span = tracing::span!(
+        tracing::Level::DEBUG,
+        "c",
+        aud = %request.aud,
+        endpoint = "/c",
+        session_id = %session_id
+    );
     let _enter = tracing_span.enter();
 
-    audience_authorizer.ensure_authorized(&request.aud).await?;
+    audience_authorizer
+        .ensure_authorized(&request.aud)
+        .await
+        .map_err(|error| {
+            if matches!(error, AudienceAuthorizationError::NotAuthorized) {
+                tracing::error!(
+                    aud = %request.aud,
+                    endpoint = "/c",
+                    session_id = %session_id,
+                    message = "Audience is not authorized"
+                );
+            }
+            RequestError::from(error)
+        })?;
 
     let token_details = TokenDetails::from_aud(request.aud.clone());
     let nonce = nonce_db.generate_nonce(&token_details).await.map_err(|e| {

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -575,6 +575,7 @@ impl std::error::Error for RequestError {}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ErrorCode {
+    AttestationRejected,
     BadRequest,
     DuplicateRequestHash,
     ExpiredToken,
@@ -585,11 +586,13 @@ pub enum ErrorCode {
     InvalidPublicKey,
     InvalidToken,
     InvalidDeveloperToken,
+    NonceNotFound,
 }
 
 impl std::fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::AttestationRejected => write!(f, "attestation_rejected"),
             Self::BadRequest => write!(f, "bad_request"),
             Self::DuplicateRequestHash => write!(f, "duplicate_request_hash"),
             Self::ExpiredToken => write!(f, "expired_token"),
@@ -600,6 +603,7 @@ impl std::fmt::Display for ErrorCode {
             Self::InvalidPublicKey => write!(f, "invalid_public_key"),
             Self::InvalidToken => write!(f, "invalid_token"),
             Self::InvalidDeveloperToken => write!(f, "invalid_developer_token"),
+            Self::NonceNotFound => write!(f, "nonce_not_found"),
         }
     }
 }
@@ -609,19 +613,25 @@ impl ErrorCode {
         match self {
             Self::InternalServerError => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             Self::DuplicateRequestHash => axum::http::StatusCode::CONFLICT,
-            Self::BadRequest
+            Self::AttestationRejected
+            | Self::BadRequest
             | Self::ExpiredToken
             | Self::IntegrityFailed
             | Self::InvalidAttestationForApp
             | Self::InvalidInitialAttestation
             | Self::InvalidPublicKey
             | Self::InvalidToken
-            | Self::InvalidDeveloperToken => axum::http::StatusCode::BAD_REQUEST,
+            | Self::InvalidDeveloperToken
+            | Self::NonceNotFound => axum::http::StatusCode::BAD_REQUEST,
         }
     }
 
     const fn into_default_error_message(self) -> &'static str {
         match self {
+            Self::AttestationRejected => "Device attestation could not be verified.",
+            Self::NonceNotFound => {
+                "The challenge nonce is unknown or has expired. Request a new challenge."
+            }
             Self::BadRequest => "The request is malformed.",
             Self::DuplicateRequestHash => "The `request_hash` has already been used.",
             Self::ExpiredToken => "The integrity token has expired. Please generate a new one.",
@@ -643,7 +653,8 @@ impl ErrorCode {
     const fn into_allow_retry(self) -> bool {
         match self {
             Self::InternalServerError => true,
-            Self::BadRequest
+            Self::AttestationRejected
+            | Self::BadRequest
             | Self::ExpiredToken
             | Self::IntegrityFailed
             | Self::InvalidAttestationForApp
@@ -651,7 +662,8 @@ impl ErrorCode {
             | Self::InvalidPublicKey
             | Self::InvalidToken
             | Self::InvalidDeveloperToken
-            | Self::DuplicateRequestHash => false,
+            | Self::DuplicateRequestHash
+            | Self::NonceNotFound => false,
         }
     }
 }

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -573,6 +573,19 @@ impl IntoResponse for RequestError {
 
 impl std::error::Error for RequestError {}
 
+/// Session identifier World App sends in the `sessionId` header on every request.
+///
+/// Used only to correlate gateway logs with client-side Datadog logs (which carry the same value
+/// as `SessionID`); it is client-controlled and must not be trusted for anything
+/// security-relevant.
+#[must_use]
+pub fn client_session_id(headers: &axum::http::HeaderMap) -> &str {
+    headers
+        .get("sessionId")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("unknown")
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ErrorCode {
     AttestationRejected,


### PR DESCRIPTION
## Motivation

Prod orb enrollment failures reach World App logs as a detail-less `WrappedRemoteError(innerError=BadRequest)`; the app can't tell an attestation reject from an expired nonce, and the gateway's verify detail string went to the client verbatim.

## What this does

`/a` returns `attestation_rejected` (Android verify reject) and `nonce_not_found` instead of `bad_request`, with coarse client messages; the precise verify failure stays in server logs only. App builds already in the field render unknown codes with code and message via their `WrappedApiError` fallback, so client-side logs improve with no app release.
