### PR TITLE
Log client sessionId header on /c and /a

### DIFF
--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -18,7 +18,7 @@ use crate::{
     android::{AndroidAttestationError, AndroidAttestationService},
     apple, keys, kms_jws,
     nonces::{NonceDb, NonceDbError},
-    utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError},
+    utils::{BundleIdentifier, ErrorCode, GlobalConfig, Platform, RequestError, client_session_id},
 };
 
 fn headers_to_map(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
@@ -119,7 +119,7 @@ impl IntegrityTokenPayload {
     }
 }
 
-fn map_android_attestation_error(e: &AndroidAttestationError) -> RequestError {
+fn map_android_attestation_error(e: &AndroidAttestationError, session_id: &str) -> RequestError {
     metrics::counter!("attestation_gateway.android_error", "reason" => e.reason_tag()).increment(1);
 
     if e.is_internal_error() {
@@ -132,7 +132,7 @@ fn map_android_attestation_error(e: &AndroidAttestationError) -> RequestError {
     } else {
         // The precise verify failure stays server-side; the client gets only the coarse
         // default message so rejection reasons don't aid attestation probing.
-        tracing::error!(endpoint = "/a", message = %e);
+        tracing::error!(endpoint = "/a", session_id = %session_id, message = %e);
         RequestError {
             code: ErrorCode::AttestationRejected,
             details: None,
@@ -172,7 +172,9 @@ pub async fn handler(
     headers: HeaderMap,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
-    let tracing_span = tracing::span!(tracing::Level::DEBUG, "a", endpoint = "/a");
+    let session_id = client_session_id(&headers);
+    let tracing_span =
+        tracing::span!(tracing::Level::DEBUG, "a", endpoint = "/a", session_id = %session_id);
     let _enter = tracing_span.enter();
 
     if !global_config
@@ -186,7 +188,7 @@ pub async fn handler(
 
     let token_details = nonce_db.consume_nonce(&request.nonce).await.map_err(|e| {
         if matches!(e, NonceDbError::NonceNotFound) {
-            tracing::error!(endpoint = "/a", message = "Nonce not found");
+            tracing::error!(endpoint = "/a", session_id = %session_id, message = "Nonce not found");
             RequestError {
                 code: ErrorCode::NonceNotFound,
                 details: None,
@@ -235,7 +237,7 @@ pub async fn handler(
                 .await;
 
             let attestation_output =
-                attestation_result.map_err(|e| map_android_attestation_error(&e))?;
+                attestation_result.map_err(|e| map_android_attestation_error(&e, session_id))?;
 
             if let Some(os_patch_level_delta) = attestation_output.os_patch_level_delta {
                 metrics::gauge!("attestation_gateway.android_os_patch_level_delta")

--- a/attestation-gateway/src/routes/c.rs
+++ b/attestation-gateway/src/routes/c.rs
@@ -1,10 +1,10 @@
-use axum::{Extension, Json};
+use axum::{Extension, Json, http::HeaderMap};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 
 use crate::audience_authorizer::{AudienceAuthorizationError, AudienceAuthorizer};
 use crate::nonces::{NonceDb, TokenDetails};
-use crate::utils::{ErrorCode, RequestError};
+use crate::utils::{ErrorCode, RequestError, client_session_id};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub struct Request {
@@ -41,13 +41,33 @@ pub struct Response {
 pub async fn handler(
     Extension(mut nonce_db): Extension<NonceDb>,
     Extension(audience_authorizer): Extension<AudienceAuthorizer>,
+    headers: HeaderMap,
     Json(request): Json<Request>,
 ) -> Result<Json<Response>, RequestError> {
-    let tracing_span =
-        tracing::span!(tracing::Level::DEBUG, "c", aud = %request.aud, endpoint = "/c");
+    let session_id = client_session_id(&headers);
+    let tracing_span = tracing::span!(
+        tracing::Level::DEBUG,
+        "c",
+        aud = %request.aud,
+        endpoint = "/c",
+        session_id = %session_id
+    );
     let _enter = tracing_span.enter();
 
-    audience_authorizer.ensure_authorized(&request.aud).await?;
+    audience_authorizer
+        .ensure_authorized(&request.aud)
+        .await
+        .map_err(|error| {
+            if matches!(error, AudienceAuthorizationError::NotAuthorized) {
+                tracing::error!(
+                    aud = %request.aud,
+                    endpoint = "/c",
+                    session_id = %session_id,
+                    message = "Audience is not authorized"
+                );
+            }
+            RequestError::from(error)
+        })?;
 
     let token_details = TokenDetails::from_aud(request.aud.clone());
     let nonce = nonce_db.generate_nonce(&token_details).await.map_err(|e| {

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -573,6 +573,19 @@ impl IntoResponse for RequestError {
 
 impl std::error::Error for RequestError {}
 
+/// Session identifier World App sends in the `sessionId` header on every request.
+///
+/// Used only to correlate gateway logs with client-side Datadog logs (which carry the same value
+/// as `SessionID`); it is client-controlled and must not be trusted for anything
+/// security-relevant.
+#[must_use]
+pub fn client_session_id(headers: &axum::http::HeaderMap) -> &str {
+    headers
+        .get("sessionId")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("unknown")
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ErrorCode {
     AttestationRejected,


### PR DESCRIPTION
## Motivation

A client-side failure can't currently be joined to the gateway request that caused it; triage is timestamp guessing across log streams.

## What this does

Logs the `sessionId` header (which World App already sends on every request) on the `/c` and `/a` route spans and error paths. It equals the `SessionID` attribute on client Datadog logs, so client-to-gateway correlation becomes a single query. The value is client-controlled and used for log correlation only; split from the error-code PR so logging a client identifier can be discussed on its own.

Stacked on the error-codes PR.
