### PR TITLE
Support release AND debug signing digests for World Id Android Sandbox

### DIFF
--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -246,18 +246,23 @@ impl AndroidAttestationService {
             return Err(AndroidAttestationError::KeyNotGeneratedInSecureHardware);
         }
 
-        let expected_attestation_signature_digest = bundle_identifier
+        let expected_attestation_signature_digests = bundle_identifier
             .android_certificate_sha256_digest_base64()
             .ok_or(AndroidAttestationError::MissingCertificateDigest)?;
 
-        let expected_attestation_signature_digest = Base64
-            .decode(expected_attestation_signature_digest)
-            .map_err(AndroidAttestationError::BadCertificateDigestEncoding)?;
+        let matches_expected_digest = expected_attestation_signature_digests
+            .iter()
+            .map(|digest| Base64.decode(digest))
+            .collect::<Result<Vec<_>, DecodeError>>()
+            .map_err(AndroidAttestationError::BadCertificateDigestEncoding)?
+            .iter()
+            .any(|digest| {
+                cert_chain
+                    .session_cert()
+                    .contains_attestation_signature_digests(digest)
+            });
 
-        if !cert_chain
-            .session_cert()
-            .contains_attestation_signature_digests(&expected_attestation_signature_digest)
-        {
+        if !matches_expected_digest {
             return Err(AndroidAttestationError::InvalidAttestationSignatureDigest);
         }
 

--- a/attestation-gateway/src/android/integrity_token_data.rs
+++ b/attestation-gateway/src/android/integrity_token_data.rs
@@ -265,10 +265,13 @@ impl PlayIntegrityToken {
             }));
         }
 
-        if let Some(digest) = bundle_identifier.android_certificate_sha256_digest() {
+        if let Some(digests) = bundle_identifier.android_certificate_sha256_digest() {
             if let Some(certificate_sha_256_digest) = &self.app_integrity.certificate_sha_256_digest
             {
-                if !certificate_sha_256_digest.contains(&digest.to_string()) {
+                if !digests
+                    .iter()
+                    .any(|digest| certificate_sha_256_digest.contains(&digest.to_string()))
+                {
                     return Err(eyre::eyre!(ClientException {
                         code: ErrorCode::IntegrityFailed,
                         internal_debug_info:

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -279,20 +279,28 @@ impl BundleIdentifier {
         }
     }
 
-    /// Expected app signing-certificate digest (hex) for Android Play Integrity (`POST /g`).
+    /// Expected app signing-certificate digest(s) (hex) for Android Play Integrity (`POST /g`).
+    ///
+    /// Returns all digests accepted for the bundle identifier; a response listing any one of
+    /// them is considered valid.
     #[must_use]
-    pub const fn android_certificate_sha256_digest(&self) -> Option<&str> {
+    pub const fn android_certificate_sha256_digest(&self) -> Option<&'static [&'static str]> {
         match self {
             Self::ComWorldcoin
             | Self::ComWorldcoinStaging
             | Self::ComWorldcoinSandbox
             | Self::OrgWorldId
-            | Self::OrgWorldIdStaging
-            | Self::OrgWorldIdSandbox => {
+            | Self::OrgWorldIdStaging => {
                 // cspell:disable-next-line
-                Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8")
+                Some(&["nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8"])
             }
-            Self::ComWorldcoinDev | Self::OrgWorldIdDev => Some("6a6a1474b5cbbb2b1aa57e0bc3"),
+            Self::OrgWorldIdSandbox => Some(&[
+                // cspell:disable-next-line
+                "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8",
+                // cspell:disable-next-line
+                "ZCvi3PWJOn5wJNMnMfkK6/XzKck4vUj9v3nOHFLSDUQ",
+            ]),
+            Self::ComWorldcoinDev | Self::OrgWorldIdDev => Some(&["6a6a1474b5cbbb2b1aa57e0bc3"]),
             Self::OrgWorldcoinInsight
             | Self::OrgWorldcoinInsightStaging
             | Self::OrgWorldcoinInsightSandbox
@@ -301,18 +309,27 @@ impl BundleIdentifier {
         }
     }
 
-    /// Expected app signing-certificate digest (base64) for Android hardware attestation (`POST /a`).
+    /// Expected app signing-certificate digest(s) (base64) for Android hardware attestation (`POST /a`).
+    ///
+    /// Returns all digests accepted for the bundle identifier; a cert chain matching any one of
+    /// them is considered valid.
     #[must_use]
-    pub const fn android_certificate_sha256_digest_base64(&self) -> Option<&'static str> {
+    pub const fn android_certificate_sha256_digest_base64(
+        &self,
+    ) -> Option<&'static [&'static str]> {
         match self {
             Self::ComWorldcoin
             | Self::ComWorldcoinStaging
             | Self::ComWorldcoinSandbox
             | Self::OrgWorldId
-            | Self::OrgWorldIdStaging
-            | Self::OrgWorldIdSandbox => Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8="),
+            | Self::OrgWorldIdStaging => Some(&["nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8="]),
+            Self::OrgWorldIdSandbox => Some(&[
+                "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=",
+                // cspell:disable-next-line
+                "ZCvi3PWJOn5wJNMnMfkK6/XzKck4vUj9v3nOHFLSDUQ=",
+            ]),
             Self::ComWorldcoinDev | Self::OrgWorldIdDev => {
-                Some("o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A=")
+                Some(&["o0Fu39yqrsxeWSucqge7eOzG8xrsRAn0nKbTtN/x2+A="])
             }
             Self::OrgWorldcoinInsight
             | Self::OrgWorldcoinInsightStaging
@@ -1034,11 +1051,39 @@ mod tests {
         assert_eq!(
             bundle.android_certificate_sha256_digest(),
             // cspell:disable-next-line
-            Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8")
+            Some(["nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8"].as_slice())
         );
         assert_eq!(
             bundle.android_certificate_sha256_digest_base64(),
-            Some("nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=")
+            Some(["nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8="].as_slice())
+        );
+    }
+
+    #[test]
+    fn org_world_id_sandbox_accepts_both_android_cert_digests() {
+        let bundle = BundleIdentifier::OrgWorldIdSandbox;
+        assert_eq!(
+            bundle.android_certificate_sha256_digest(),
+            Some(
+                [
+                    // cspell:disable-next-line
+                    "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8",
+                    // cspell:disable-next-line
+                    "ZCvi3PWJOn5wJNMnMfkK6/XzKck4vUj9v3nOHFLSDUQ",
+                ]
+                .as_slice()
+            )
+        );
+        assert_eq!(
+            bundle.android_certificate_sha256_digest_base64(),
+            Some(
+                [
+                    "nSrXEn8JkZKXFMAZW0NHhDRTHNi38YE2XCvVzYXjRu8=",
+                    // cspell:disable-next-line
+                    "ZCvi3PWJOn5wJNMnMfkK6/XzKck4vUj9v3nOHFLSDUQ=",
+                ]
+                .as_slice()
+            )
         );
     }
 


### PR DESCRIPTION
For the Sandbox builds of World Id App, we want to support debug builds so that developers have the benefit of debugging issues while testing attestation flows. Thus, this commit modifies the digest check to check for any one of potentially multiple digests to match. For now, we are only supporting the debug/release duality for Android World Id Sandbox. But we can support other dualities in the future.

We discussed this as a team and determined the security risk of doing this was still low, since the allowlist is still a bounded and very small set. In other words, it's not a wildcard nor an open-allow.

**NOTE:** The code changes were 100% authored by Claude.

**Tests Ran Locally:**
* docker compose -f attestation-gateway/tests/docker-compose.test.yml up -d
* cargo test
* All tests passed.

**IMPORTANT:** I don't know how to test this in real life (deploy and test, unless there's some magic way to do this via Docker). I am solely relying on unit tests in this case, but if there is in fact a way to deploy this to a test server and I can point my app at it, let me know.