### PR TITLE
SEC-2780: Validate StrongBox certificate chain shape

### DIFF
--- a/attestation-gateway/src/android/android_attestation_service.rs
+++ b/attestation-gateway/src/android/android_attestation_service.rs
@@ -49,6 +49,9 @@ pub enum AndroidAttestationError {
     #[error("inconsistent security levels")]
     InconsistentSecurityLevels,
 
+    #[error("StrongBox security level does not match certificate chain")]
+    StrongBoxChainMismatch,
+
     #[error("device not locked")]
     DeviceNotLocked,
 
@@ -219,6 +222,13 @@ impl AndroidAttestationService {
             return Err(AndroidAttestationError::InconsistentSecurityLevels);
         }
 
+        if !security_level_matches_chain(
+            &cert_chain.session_cert().attestation_security_level(),
+            cert_chain.has_strong_box_chain_shape(),
+        ) {
+            return Err(AndroidAttestationError::StrongBoxChainMismatch);
+        }
+
         let verified_boot_state = cert_chain
             .session_cert()
             .verified_boot_state()
@@ -295,6 +305,13 @@ impl AndroidAttestationService {
     }
 }
 
+fn security_level_matches_chain(
+    attestation_security_level: &SecurityLevel,
+    has_strong_box_chain_shape: bool,
+) -> bool {
+    attestation_security_level != &SecurityLevel::StrongBox || has_strong_box_chain_shape
+}
+
 impl AndroidAttestationError {
     pub fn reason_tag(&self) -> String {
         match self {
@@ -312,6 +329,7 @@ impl AndroidAttestationError {
             Self::InvalidChallenge => "invalid_challenge".to_string(),
             Self::LowSecurityLevel => "low_security_level".to_string(),
             Self::InconsistentSecurityLevels => "inconsistent_security_levels".to_string(),
+            Self::StrongBoxChainMismatch => "strong_box_chain_mismatch".to_string(),
             Self::DeviceNotLocked => "device_not_locked".to_string(),
             Self::BootNotVerified => "boot_not_verified".to_string(),
             Self::KeyNotGeneratedInSecureHardware => {
@@ -343,6 +361,7 @@ impl AndroidAttestationError {
             | Self::InvalidChallenge
             | Self::LowSecurityLevel
             | Self::InconsistentSecurityLevels
+            | Self::StrongBoxChainMismatch
             | Self::DeviceNotLocked
             | Self::BootNotVerified
             | Self::KeyNotGeneratedInSecureHardware
@@ -353,5 +372,34 @@ impl AndroidAttestationError {
             | Self::CertificateRevoked => false,
             Self::MissingCertificateDigest | Self::BadCertificateDigestEncoding(_) => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_strong_box_claim_without_strong_box_chain_shape() {
+        assert!(!security_level_matches_chain(
+            &SecurityLevel::StrongBox,
+            false
+        ));
+    }
+
+    #[test]
+    fn accepts_strong_box_claim_with_strong_box_chain_shape() {
+        assert!(security_level_matches_chain(
+            &SecurityLevel::StrongBox,
+            true
+        ));
+    }
+
+    #[test]
+    fn accepts_tee_without_strong_box_chain_shape() {
+        assert!(security_level_matches_chain(
+            &SecurityLevel::TrustedEnvironment,
+            false
+        ));
     }
 }

--- a/attestation-gateway/src/android/cert_chain.rs
+++ b/attestation-gateway/src/android/cert_chain.rs
@@ -179,6 +179,17 @@ impl CertChain {
     pub const fn root_cert(&self) -> &RootCert {
         &self.root_cert
     }
+
+    /// StrongBox factory and remotely provisioned chains identify StrongBox in the
+    /// subject of the attestation certificate or the final intermediate certificate.
+    #[must_use]
+    pub fn has_strong_box_chain_shape(&self) -> bool {
+        self.device_cert().subject_contains_strong_box()
+            || self
+                .intermediate_certs()
+                .last()
+                .is_some_and(IntermediateCert::subject_contains_strong_box)
+    }
 }
 
 impl CertChainError {

--- a/attestation-gateway/src/android/cert_chain_builder.rs
+++ b/attestation-gateway/src/android/cert_chain_builder.rs
@@ -272,6 +272,9 @@ mod tests {
             .build_chain_from_base64(&[cert1.clone(), cert3.clone(), cert2.clone()])
             .unwrap();
 
+        assert!(cert_chain1.has_strong_box_chain_shape());
+        assert!(cert_chain2.has_strong_box_chain_shape());
+
         assert_eq!(
             cert_chain1.session_cert().serial(),
             cert_chain2.session_cert().serial()

--- a/attestation-gateway/src/android/intermediate_cert.rs
+++ b/attestation-gateway/src/android/intermediate_cert.rs
@@ -26,19 +26,31 @@ pub struct IntermediateCert {
     #[serde(with = "crate::android::serde_hex")]
     public_key: Vec<u8>,
     serial: CertSerial,
+    #[serde(skip)]
+    subject_contains_strong_box: bool,
 }
 
 impl IntermediateCert {
     pub fn from_x509(cert: &X509) -> Result<Self, IntermediateCertError> {
         let serial = CertSerial::from_x509(cert).map_err(IntermediateCertError::Serial)?;
+        let subject_contains_strong_box = cert.subject_name().entries().any(|entry| {
+            entry
+                .data()
+                .to_string()
+                .is_ok_and(|value| value.to_ascii_lowercase().contains("strongbox"))
+        });
         let der = cert
             .to_der()
             .map_err(|_| IntermediateCertError::DerEncoding)?;
 
-        Self::from_der_with_serial(&der, serial)
+        Self::from_der_with_serial(&der, serial, subject_contains_strong_box)
     }
 
-    fn from_der_with_serial(der: &[u8], serial: CertSerial) -> Result<Self, IntermediateCertError> {
+    fn from_der_with_serial(
+        der: &[u8],
+        serial: CertSerial,
+        subject_contains_strong_box: bool,
+    ) -> Result<Self, IntermediateCertError> {
         let (_, cert) =
             X509Certificate::from_der(der).map_err(|_| IntermediateCertError::DerDecoding)?;
 
@@ -52,7 +64,11 @@ impl IntermediateCert {
 
         let public_key = Vec::from(cert.public_key().subject_public_key.data.clone());
 
-        Ok(Self { public_key, serial })
+        Ok(Self {
+            public_key,
+            serial,
+            subject_contains_strong_box,
+        })
     }
 
     pub const fn serial(&self) -> &CertSerial {
@@ -65,6 +81,10 @@ impl IntermediateCert {
 
     pub fn public_key_hex(&self) -> String {
         hex::encode(self.public_key())
+    }
+
+    pub const fn subject_contains_strong_box(&self) -> bool {
+        self.subject_contains_strong_box
     }
 }
 


### PR DESCRIPTION
## Summary
- derive StrongBox evidence from the verified attestation certificate chain
- reject leaf extensions that claim StrongBox without a matching chain shape
- preserve generic TEE hardware attestation behavior

## Why
The leaf currently supplies both security-level fields, so their equality does not independently prove StrongBox. This closes the gap described in [GHSA-frpv-cj76-xm4r](https://github.com/a-sit-plus/warden-supreme/security/advisories/GHSA-frpv-cj76-xm4r).

Linear: https://linear.app/worldcoin/issue/SEC-2780

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test android::`
- [x] `cargo clippy`