### PR TITLE
Accept multiple Apple App IDs for iOS App Attest

### DIFF
--- a/attestation-gateway/src/apple/mod.rs
+++ b/attestation-gateway/src/apple/mod.rs
@@ -44,7 +44,7 @@ pub async fn verify_initial_attestation(
     let attestation_result = decode_and_validate_initial_attestation(
         apple_initial_attestation,
         &request_hash,
-        bundle_identifier.apple_app_id().context(format!(
+        &bundle_identifier.apple_accepted_app_ids().context(format!(
             "Cannot retrieve `app_id` for bundle identifier: {bundle_identifier}"
         ))?,
         &AAGUID::allowed_for_bundle_identifier(&bundle_identifier)?,
@@ -101,7 +101,7 @@ pub async fn verify(
     let counter = decode_and_validate_assertion(
         apple_assertion,
         key.public_key,
-        bundle_identifier.apple_app_id().context(format!(
+        &bundle_identifier.apple_accepted_app_ids().context(format!(
             "Cannot retrieve `app_id` for bundle identifier: {bundle_identifier}"
         ))?,
         request_hash,
@@ -201,14 +201,42 @@ pub struct InitialAttestationOutput {
     pub key_public_key: Vec<u8>,
 }
 
+/// Confirms `rp_id` (the SHA-256 app-id hash carried in an attestation/assertion) matches one of
+/// the `accepted_app_ids`. Fails closed with `InvalidAttestationForApp` when none match.
+fn verify_rp_id_against_accepted(
+    rp_id: &[u8],
+    accepted_app_ids: &[&str],
+    object_kind: &str,
+) -> eyre::Result<()> {
+    let any_match = accepted_app_ids.iter().any(|app_id| {
+        let mut hasher = Sha256::new();
+        hasher.update(app_id.as_bytes());
+        let hashed_app_id: &[u8] = &hasher.finish();
+        rp_id == hashed_app_id
+    });
+
+    if !any_match {
+        eyre::bail!(ClientException {
+            code: ErrorCode::InvalidAttestationForApp,
+            internal_debug_info: format!(
+                "expected `app_id` for bundle identifier and `rp_id` from {object_kind} object do not match."
+            ),
+        });
+    }
+    Ok(())
+}
+
 /// Implements the verification of `DeviceCheck` *attestations* for iOS.
 ///
 /// Attestations are sent the first time to attest to the validity of a specific public key.
 /// <https://developer.apple.com/documentation/devicecheck/validating_apps_that_connect_to_your_server#3576643>
+///
+/// The step-6 `rp_id` check passes if the attestation matches any of `accepted_app_ids` (see
+/// `BundleIdentifier::apple_accepted_app_ids`).
 pub fn decode_and_validate_initial_attestation(
     apple_initial_attestation: String,
     challenge: &str,
-    expected_app_id: &str,
+    accepted_app_ids: &[&str],
     allowed_aaguid: &[AAGUID],
     apple_root_ca_pem: &[u8],
 ) -> eyre::Result<InitialAttestationOutput> {
@@ -278,19 +306,9 @@ pub fn decode_and_validate_initial_attestation(
     let public_key_der = cert.public_key()?.public_key_to_der()?;
     let public_key = res.public_key().subject_public_key.clone().data;
 
-    // Step 6: check app_id
+    // Step 6: check app_id against the accepted list
     let rp_id = &attestation.auth_data.clone()[0..32];
-    let mut hasher = Sha256::new();
-    hasher.update(expected_app_id.as_bytes());
-    let hashed_app_id: &[u8] = &hasher.finish();
-
-    if rp_id != hashed_app_id {
-        eyre::bail!(ClientException {
-            code: ErrorCode::InvalidAttestationForApp,
-            internal_debug_info: "expected `app_id` for bundle identifier and `rp_id` from attestation object do not match."
-                .to_string(),
-        });
-    }
+    verify_rp_id_against_accepted(rp_id, accepted_app_ids, "attestation")?;
 
     // Step 7: counter check
     let counter = u32::from_be_bytes(attestation.auth_data.clone()[33..37].try_into()?);
@@ -370,10 +388,12 @@ fn internal_verify_cert_chain_with_store(
 
 /// Implements the verification of `DeviceCheck` *assertions* for iOS.
 /// <https://developer.apple.com/documentation/devicecheck/validating_apps_that_connect_to_your_server#3576644>
+///
+/// The step-4 `rp_id` check passes if the assertion matches any of `accepted_app_ids`.
 fn decode_and_validate_assertion(
     assertion: String,
     public_key: String,
-    expected_app_id: &str,
+    accepted_app_ids: &[&str],
     request_hash: &str,
     last_counter: u32,
 ) -> eyre::Result<u32> {
@@ -410,19 +430,9 @@ fn decode_and_validate_assertion(
         });
     }
 
-    // Step 4: check app_id
+    // Step 4: check app_id against the accepted list
     let rp_id = &assertion.authenticator_data.clone()[0..32];
-    let mut hasher = Sha256::new();
-    hasher.update(expected_app_id.as_bytes());
-    let hashed_app_id: &[u8] = &hasher.finish();
-
-    if rp_id != hashed_app_id {
-        eyre::bail!(ClientException {
-            code: ErrorCode::InvalidAttestationForApp,
-            internal_debug_info: "expected `app_id` for bundle identifier and `rp_id` from assertion object do not match."
-                .to_string(),
-        });
-    }
+    verify_rp_id_against_accepted(rp_id, accepted_app_ids, "assertion")?;
 
     // Step 5: Counter check
     let counter = u32::from_be_bytes(assertion.authenticator_data.clone()[33..37].try_into()?);

--- a/attestation-gateway/src/apple/tests.rs
+++ b/attestation-gateway/src/apple/tests.rs
@@ -16,7 +16,7 @@ fn test_verify_initial_attestation_success_with_test_attestation() {
     let result = decode_and_validate_initial_attestation(
         test_data.attestation_base64,
         request_hash,
-        app_id,
+        &[app_id],
         &[AAGUID::AppAttestDevelop],
         &test_data.root_ca_pem,
     )
@@ -255,9 +255,9 @@ fn test_verify_initial_attestation_failure_on_invalid_attestation() {
     let result = decode_and_validate_initial_attestation(
         "this_is_not_base64_encoded".to_string(),
         "test",
-        BundleIdentifier::OrgWorldcoinInsightStaging
+        &[BundleIdentifier::OrgWorldcoinInsightStaging
             .apple_app_id()
-            .unwrap(),
+            .unwrap()],
         &[AAGUID::AppAttestDevelop],
         include_bytes!("./apple_app_attestation_root_ca.pem"),
     )
@@ -281,9 +281,9 @@ fn test_verify_initial_attestation_failure_on_invalid_cbor_message() {
         // cspell:disable-next-line
         "dGhpcyBpcyBpbnZhbGlk".to_string(),
         "test",
-        BundleIdentifier::OrgWorldcoinInsightStaging
+        &[BundleIdentifier::OrgWorldcoinInsightStaging
             .apple_app_id()
-            .unwrap(),
+            .unwrap()],
         &[AAGUID::AppAttestDevelop],
         include_bytes!("./apple_app_attestation_root_ca.pem"),
     )
@@ -308,7 +308,7 @@ fn test_verify_initial_attestation_failure_nonce_mismatch() {
     let result = decode_and_validate_initial_attestation(
         test_data.attestation_base64,
         "hash_b",
-        app_id,
+        &[app_id],
         &[AAGUID::AppAttestDevelop],
         &test_data.root_ca_pem,
     )
@@ -338,7 +338,7 @@ fn test_verify_initial_attestation_failure_app_id_mismatch() {
     let result = decode_and_validate_initial_attestation(
         test_data.attestation_base64,
         request_hash,
-        prod_app_id,
+        &[prod_app_id],
         &[AAGUID::AppAttestDevelop],
         &test_data.root_ca_pem,
     )
@@ -366,7 +366,7 @@ fn test_verify_initial_attestation_failure_aaguid_mismatch() {
     let result = decode_and_validate_initial_attestation(
         test_data.attestation_base64,
         request_hash,
-        app_id,
+        &[app_id],
         &[AAGUID::AppAttest],
         &test_data.root_ca_pem,
     )
@@ -398,7 +398,7 @@ fn test_verify_initial_attestation_bypassing_aaguid_check_for_staging_apps() {
     decode_and_validate_initial_attestation(
         test_data.attestation_base64,
         request_hash,
-        app_id,
+        &[app_id],
         &expected_aaguids,
         &test_data.root_ca_pem,
     )
@@ -425,7 +425,7 @@ fn verify_assertion_success() {
         valid_assertion.to_string(),
         // notice this is the public key from test_verify_initial_attestation_success
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu5PyE6mg2JOA19zIosBmv/18/3B5ySWGLET7mQhWijPWWtKPEjdfDME7djEYaT81tvWoXXm95qfBYZw3Q2YDmQ==".to_string(),
-        BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap(),
+        &[BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap()],
         "02072cdf5e347d876a89949e6c11febb55716e3e7026e76b7d90d0bed6cf28e9",
         0,
     );
@@ -442,7 +442,7 @@ fn verify_assertion_success_two() {
         valid_assertion.to_string(),
         // notice this is the public key from test_verify_initial_attestation_success
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh4Bd1IrEnNal/KNplK6VVrByUq4jsVtVVxpMI/mezeQcluflXHikUxYe+xoB/fAL3VnEA5zJlLobpHcfn/4+7w==".to_string(),
-        BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap(),
+        &[BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap()],
         "test",
         0,
     );
@@ -458,7 +458,7 @@ fn verify_assertion_failure_with_invalid_counter() {
         valid_assertion.to_string(),
         // notice this is the public key from test_verify_initial_attestation_success
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh4Bd1IrEnNal/KNplK6VVrByUq4jsVtVVxpMI/mezeQcluflXHikUxYe+xoB/fAL3VnEA5zJlLobpHcfn/4+7w==".to_string(),
-        BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap(),
+        &[BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap()],
         "test",
         1,
     ).unwrap_err();
@@ -480,7 +480,7 @@ fn verify_assertion_failure_with_invalid_hash() {
         valid_assertion.to_string(),
         // notice this is the public key from test_verify_initial_attestation_success
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh4Bd1IrEnNal/KNplK6VVrByUq4jsVtVVxpMI/mezeQcluflXHikUxYe+xoB/fAL3VnEA5zJlLobpHcfn/4+7w==".to_string(),
-        BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap(),
+        &[BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap()],
         "not_the_hash_i_expect",
         0,
     ).unwrap_err();
@@ -538,7 +538,7 @@ fn verify_assertion_failure_with_invalid_key() {
          encoded_assertion,
         // notice this public key does not match the `fake_public_key` generated above
          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh4Bd1IrEnNal/KNplK6VVrByUq4jsVtVVxpMI/mezeQcluflXHikUxYe+xoB/fAL3VnEA5zJlLobpHcfn/4+7w==".to_string(),
-        BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap(),
+        &[BundleIdentifier::OrgWorldcoinInsightStaging.apple_app_id().unwrap()],
         request_hash,
         0,
     )
@@ -594,9 +594,9 @@ fn verify_assertion_failure_with_invalid_authenticator_data() {
     let result = decode_and_validate_assertion(
         encoded_assertion,
         general_purpose::STANDARD.encode(fake_key.public_key_to_der().unwrap()),
-        BundleIdentifier::OrgWorldcoinInsightStaging
+        &[BundleIdentifier::OrgWorldcoinInsightStaging
             .apple_app_id()
-            .unwrap(),
+            .unwrap()],
         request_hash,
         0,
     )

--- a/attestation-gateway/src/routes/a.rs
+++ b/attestation-gateway/src/routes/a.rs
@@ -282,10 +282,12 @@ fn validate_apple_attestation_and_get_device_public_key(
     let allowed_aaguid_vec = apple::AAGUID::allowed_for_bundle_identifier(bundle_identifier)
         .map_err(|_| bad_request("Invalid bundle identifier"))?;
 
+    // Canonical App ID only — the re-signed-build allow-list is intentionally scoped to the
+    // `/g` token flow (via `apple_accepted_app_ids`); this `/a` route is unchanged.
     let initial_attestation = apple::decode_and_validate_initial_attestation(
         apple_attestation,
         challenge,
-        app_id,
+        &[app_id],
         allowed_aaguid_vec.as_slice(),
         apple_root_ca_pem,
     )

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -342,6 +342,26 @@ impl BundleIdentifier {
             // cspell:enable
         }
     }
+
+    /// The App IDs accepted for iOS App Attest for this bundle. Normally just the canonical
+    /// [`Self::apple_app_id`]; staging additionally accepts the App ID of re-signed automation
+    /// builds. `None` for non-Apple bundles (mirrors `apple_app_id`).
+    ///
+    /// TEMPORARY: the staging extra lets AWS Device Farm's wildcard re-sign (Apple Team
+    /// `5VLXJ89ZV9`) pass attestation so UI automation can run on real devices. Production
+    /// deployments reject staging bundles at the `enabled_bundle_identifiers` gate before
+    /// attestation, so this never widens production. Remove when device-farm automation no
+    /// longer needs it.
+    #[must_use]
+    pub fn apple_accepted_app_ids(&self) -> Option<Vec<&str>> {
+        let mut ids = vec![self.apple_app_id()?];
+        // cspell:disable-next-line
+        if matches!(self, Self::OrgWorldStagingId) {
+            // cspell:disable-next-line
+            ids.push("5VLXJ89ZV9.org.world.staging.id");
+        }
+        Some(ids)
+    }
 }
 
 impl Display for BundleIdentifier {
@@ -1109,6 +1129,54 @@ mod tests {
             None
         );
         assert_eq!(BundleIdentifier::OrgWorldStagingId.android_app(), None);
+    }
+
+    #[test]
+    fn apple_accepted_app_ids_always_contain_canonical() {
+        // Whatever else is accepted, a bundle's canonical App ID must always be — otherwise
+        // real store-signed apps would fail attestation.
+        for bundle in [
+            BundleIdentifier::OrgWorldId,
+            BundleIdentifier::OrgWorldStagingId,
+            BundleIdentifier::OrgWorldSandboxId,
+            BundleIdentifier::OrgWorldcoinInsight,
+            BundleIdentifier::OrgWorldcoinInsightStaging,
+            BundleIdentifier::OrgWorldcoinInsightSandbox,
+        ] {
+            let accepted = bundle.apple_accepted_app_ids().unwrap();
+            assert!(accepted.contains(&bundle.apple_app_id().unwrap()));
+        }
+    }
+
+    #[test]
+    fn production_bundles_accept_only_their_canonical_app_id() {
+        // The invariant that keeps re-signed builds out of production: a production bundle must
+        // accept exactly its one canonical App ID — never an extra. (Non-prod bundles may carry
+        // an extra; the staging one does today, asserted below.)
+        for bundle in [
+            BundleIdentifier::OrgWorldId,
+            BundleIdentifier::OrgWorldcoinInsight,
+            BundleIdentifier::ComWorldcoin,
+        ] {
+            let app_ids = bundle
+                .apple_accepted_app_ids()
+                .map(|ids| ids.len())
+                .unwrap_or(1);
+            assert_eq!(
+                app_ids, 1,
+                "{bundle} is a production bundle and must accept only its canonical App ID"
+            );
+        }
+        assert_eq!(
+            BundleIdentifier::OrgWorldStagingId
+                .apple_accepted_app_ids()
+                .unwrap(),
+            // cspell:disable-next-line
+            vec![
+                "35RXKB6738.org.world.staging.id",
+                "5VLXJ89ZV9.org.world.staging.id"
+            ],
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Problem:
On staging we need to accept App Attest attestations from re-signed automation builds (AWS Device Farm re-signs under its own Apple Team, so the app attests a different App ID). 

### Solution:
Match the attestation/assertion rp_id against a list of accepted App IDs instead of a single one.

### Future Stuff:
This might not be needed after LP rolls out, but for now it hopefully will unblock regression testing on staging for ios.