### PR TITLE
fix(SEC-2830): accept legacy factory chains rejected by OpenSSL policy checks

### DIFF
--- a/attestation-gateway/src/android/cert_chain_builder.rs
+++ b/attestation-gateway/src/android/cert_chain_builder.rs
@@ -153,7 +153,20 @@ impl CertChainBuilder {
                 match Self::verify_cert_chain(cert_chain, &legacy_cert_store) {
                     Ok(verified_cert_chain) => verified_cert_chain,
                     Err(CertChainBuilderBuildChainError::Verification(_, _)) => {
-                        return Err(CertChainBuilderBuildChainError::Verification(error, depth));
+                        // Some factory-provisioned devices ship an attestation certificate
+                        // marked CA:FALSE, and some ship a leaf whose CRL distribution point
+                        // does not parse. OpenSSL treats both as fatal; Google's verifier
+                        // looks at neither. Fall back to Google's rule set for these chains.
+                        if !self
+                            .legacy_chain_matches_google_rules(cert_chain)
+                            .map_err(|_| CertChainBuilderBuildChainError::InternalContextVerify)?
+                        {
+                            return Err(CertChainBuilderBuildChainError::Verification(
+                                error, depth,
+                            ));
+                        }
+
+                        cert_chain.to_vec()
                     }
                     Err(error) => return Err(error),
                 }
@@ -230,6 +243,69 @@ impl CertChainBuilder {
         }
 
         Ok(store_builder.build())
+    }
+
+    /// Validates a legacy factory-provisioned chain the way Google's own
+    /// `KeyAttestationCertPathValidator` does: canonical issuer to subject name chaining, a
+    /// signature check on every link, and a terminal certificate pinned by public key.
+    ///
+    /// It deliberately ignores `basicConstraints`, `keyUsage` and CRL distribution points.
+    /// Google checks none of the three, and enough factory-provisioned devices encode them
+    /// incorrectly that OpenSSL's RFC 5280 path validation locks those devices out for good.
+    /// Certificate validity is not re-checked here because the caller has already accepted the
+    /// chain's dates through [`legacy_factory_chain_dates_are_acceptable`].
+    ///
+    /// This is only reachable for chains that terminate at the pinned legacy Google root, and
+    /// [`CertChain::from_x509`] still rejects an attestation extension on any certificate below
+    /// the leaf, which is what prevents a caller extending the chain with a forged leaf.
+    fn legacy_chain_matches_google_rules(
+        &self,
+        cert_chain: &[X509],
+    ) -> Result<bool, openssl::error::ErrorStack> {
+        let Some((root_cert, issued_certs)) = cert_chain.split_last() else {
+            return Ok(false);
+        };
+
+        if issued_certs.is_empty() || !self.is_pinned_legacy_root(root_cert)? {
+            return Ok(false);
+        }
+
+        for certs in cert_chain.windows(2) {
+            let [cert, issuer] = certs else {
+                return Ok(false);
+            };
+
+            if cert.issuer_name().try_cmp(issuer.subject_name())? != Ordering::Equal {
+                return Ok(false);
+            }
+
+            let issuer_public_key = issuer.public_key()?;
+
+            if !cert.verify(&issuer_public_key)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Matches a certificate against the pinned legacy Google root by public key rather than by
+    /// name, so that a chain terminating in one of Google's previously issued root certificates
+    /// is accepted while a look-alike self-signed certificate is not.
+    fn is_pinned_legacy_root(&self, cert: &X509) -> Result<bool, openssl::error::ErrorStack> {
+        let cert_public_key = cert.public_key()?.public_key_to_der()?;
+
+        for trusted_cert in self
+            .trusted_certs
+            .iter()
+            .filter(|trusted_cert| is_legacy_google_root(trusted_cert))
+        {
+            if trusted_cert.public_key()?.public_key_to_der()? == cert_public_key {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
     }
 
     fn build_legacy_cert_store_without_time_checks(
@@ -346,6 +422,9 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
 
+    #[allow(unused_imports)]
+    use crate::android::intermediate_cert::IntermediateCertError;
+
     #[test]
     fn identifies_only_legacy_google_root() {
         let cert_chain_builder = CertChainBuilder::new_from_default_pem().unwrap();
@@ -376,6 +455,116 @@ mod tests {
         cert_chain_builder
             .build_chain_from_base64(&[cert1, cert2, cert3, cert4])
             .unwrap();
+    }
+
+    /// Sony SOV37 chain whose factory attestation certificate is marked CA:FALSE.
+    #[allow(dead_code)]
+    const LEGACY_NON_CA_INTERMEDIATE_CHAIN: [&str; 4] = [
+        "MIICdjCCAhugAwIBAgIBATAKBggqhkjOPQQDAjAbMRkwFwYDVQQFExA1YTc1MjE4YWNkN2EwMGY4MB4XDTcwMDEwMTAwMDAwMFoXDTI2MDcyODIzMjAyMVowHzEdMBsGA1UEAwwUQW5kcm9pZCBLZXlzdG9yZSBLZXkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS4cxIWBBLdF0xdHymyUqGXdyfVPRcL5yGAcGvJ0WKnV01D65RrOeleheB+4nhki0iMJnkibHNDH5f+ExFcuvwoo4IBSjCCAUYwDgYDVR0PAQH/BAQDAgeAMIIBMgYKKwYBBAHWeQIBEQSCASIwggEeAgECCgEBAgEDCgEBBC5uPTBiZjIwNTc5Njk4ODZiZDQ2OGY3Yjk1ZTQzMTdjMjY5LGF2PTQuMC4zMTAwBAAwaL+DEQgCBgGfqwd3CL+DEggCBgGfqwd3CL+FPQgCBgGfqwLjCb+FRUAEPjA8MRYwFAQNY29tLndvcmxkY29pbgIDPRUcMSIEIJ0q1xJ/CZGSlxTAGVtDR4Q0UxzYt/GBNlwr1c2F40bvMHShBTEDAgECogMCAQOjBAICAQClCDEGAgEEAgEAqgMCAQG/g3cCBQC/hT4DAgEAv4U/AgUAv4VAKjAoBCCUuLTjJgtL+CEaAs8vPeJXoSfP+y5AR9VYCnUqXiU94AEB/woBAL+FQQUCAwGGoL+FQgUCAwMVETAKBggqhkjOPQQDAgNJADBGAiEAybibMibgKNJ0WZ4BHjVik1ItuycznPZ7Gb1Jfd2aKlMCIQDUF8IXdSWl+KbQzoLGFPFaU/9dKKfOZA44GpR04X8z7g==",
+        "MIICLTCCAbKgAwIBAgIKB1AXSDaGMCEUdzAKBggqhkjOPQQDAjAbMRkwFwYDVQQFExBiZTQwNjQ2NmJlYTM3ODJiMB4XDTE2MDUyNjE3MzQzNFoXDTI2MDUyNDE3MzQzNFowGzEZMBcGA1UEBRMQNWE3NTIxOGFjZDdhMDBmODBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABJ0sYVr/bwpAZPtb0Q5iK8ikndwiLo4HOJb1Oj7tsriClhyYD6ctBwU96KL4F3n0gLyf9DvoT1/rxvX3Cu5V2C2jgd0wgdowHQYDVR0OBBYEFGUKaWDELNcR03vVFgnbmXkGLW13MB8GA1UdIwQYMBaAFKaz3r8xYJllfb5LA5tz0LBld0oBMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMCQGA1UdHgQdMBugGTAXghVpbnZhbGlkO2VtYWlsOmludmFsaWQwVAYDVR0fBE0wSzBJoEegRYZDaHR0cHM6Ly9hbmRyb2lkLmdvb2dsZWFwaXMuY29tL2F0dGVzdGF0aW9uL2NybC8wNzUwMTc0ODM2ODYzMDIxMTQ3NzAKBggqhkjOPQQDAgNpADBmAjEAiwRIehqwTQv1TbA4iIwQAL1GbS2flLtVP8ech8EU/rkd0OUytgx2wCSAu2C18W1hAjEA0cxt2UNcfglBZVvIW8LXGdbMteNIVEVcsvN5FenXAUtbkW4b+sloU4MsdQv5UO7T",
+        "MIIDwzCCAaugAwIBAgIKA4gmZ2BliZaFdzANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MB4XDTE2MDUyNjE3MjIxOVoXDTI2MDUyNDE3MjIxOVowGzEZMBcGA1UEBRMQYmU0MDY0NjZiZWEzNzgyYjB2MBAGByqGSM49AgEGBSuBBAAiA2IABNG7VnbdYr9743R76MZBPgjpEy54v1pz7FyAgnATGLfiCjHvXtxmT7uvCB0bUvGPTfU2JMoKGXjxBBVA2RVDN01jZ65EpXntTvctKV9SlwFgubp0w4tB0IJNGo5SxOF1YaOBtjCBszAdBgNVHQ4EFgQUprPevzFgmWV9vksDm3PQsGV3SgEwHwYDVR0jBBgwFoAUNmHhAHyIBQlRi0RsR/8aTMnqTxIwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwUAYDVR0fBEkwRzBFoEOgQYY/aHR0cHM6Ly9hbmRyb2lkLmdvb2dsZWFwaXMuY29tL2F0dGVzdGF0aW9uL2NybC9FOEZBMTk2MzE0RDJGQTE4MA0GCSqGSIb3DQEBCwUAA4ICAQCmQbMLG+NeRm6A/rtF1pgD8q8Sd+13RCC24gMBhpdcgSJfPRF4f7Y61d2NL8OlGhVCJoqXvxVXx3lJNYJAwLeZIKk9iwZaJ7BI6zpxJUFaaGzf6793Z1jNLeqAMBbluxbSik+ZHdY1m/2kjLKqOIrYniCubahKl/OwsQeTJibATNaSe1IbSxZGBgzgRYtpQGIUvPk4wJ9Zs1Z/drsAZ70LciS3T+68WFjWiBzoXZ1JBG9BpR0zQzkxN2jkSAtBmGLagR1WGbxwwehThcBi7cGCJVGGFv0TbvZOtmoaa0E+zPcDz0HTxk+YalABrLeUrRC9DtEl+lwM8TNzruG7/+r89Wga40/WxcTrdAFCExsKx6Q3RC5wMVvesUSlsa9nndLUzZbRdiyS+x477gqDt6JwQ2ZLYxpt0D94czJd9KY4YY246i/ge0ggAfrozoOquXWnfHb0j73SS6ZFU8uX6o8+M9Aac/ZMcLVFeXUCF67Sxjce0cFRKaFs63Dhph8MKjIvtsue+LxhCJ8agrULkqvNeT+6TxYicH8Hj7K8BJmlVHsM35o90OHQtn5h755+Fjtrgcvnk0o1C/cfc4WzejGEgDuY9M6Z6kxdNKdomAV8YupF2PLwjdessamdr66tyt08Tea1zsxJ6e6Z/jkRFtAKbAUsfeqAD+aBWNgu5/XzFg==",
+        "MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNVBAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYyODUyWjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdSSxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggjnar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGqC4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQoVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+OJtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/EgsTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRiigHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+MRPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9EaDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5UmAGMCAwEAAaOBpjCBozAdBgNVHQ4EFgQUNmHhAHyIBQlRi0RsR/8aTMnqTxIwHwYDVR0jBBgwFoAUNmHhAHyIBQlRi0RsR/8aTMnqTxIwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwQAYDVR0fBDkwNzA1oDOgMYYvaHR0cHM6Ly9hbmRyb2lkLmdvb2dsZWFwaXMuY29tL2F0dGVzdGF0aW9uL2NybC8wDQYJKoZIhvcNAQELBQADggIBACDIw41L3KlXG0aMiS//cqrG+EShHUGo8HNsw30W1kJtjn6UBwRM6jnmiwfBPb8VA91chb2vssAtX2zbTvqBJ9+LBPGCdw/E53Rbf86qhxKaiAHOjpvAy5Y3m00mqC0w/Zwvju1twb4vhLaJ5NkUJYsUS7rmJKHHBnETLi8GFqiEsqTWpG/6ibYCv7rYDBJDcR9W62BW9jfIoBQcxUCUJouMPH25lLNcDc1ssqvC2v7iUgI9LeoM1sNovqPmQUiG9rHli1vXxzCyaMTjwftkJLkf6724DFhuKug2jITV0QkXvaJWF4nUaHOTNA4uJU9WDvZLI1j83A+/xnAJUucIv/zGJ1AMH2boHqF8CY16LpsYgBt6tKxxWH00XcyDCdW2KlBCeqbQPcsFmWyWugxdcekhYsAWyoSf818NUsZdBWBaR/OukXrNLfkQ79IyZohZbvabO/X+MVT3rriAoKc8oE2Uws6DF+60PV7/WIPjNvXySdqspImSN78mflxDqwLqRBYkA3I75qppLGG9rp7UCdRjxMl8ZDBld+7yvHVgt1cVzJx9xnyGCC23UaicMDSXYrB4I4WHXPGjxhZuCuPBLTdOLU8YRvMYdEvYebWHMpvwGCF6bAx3JBpIeOQ1wDB5y0USicV3YgYGmi+NZfhA4URSh77Yd6uuJOJENRaNVTzk",
+    ];
+
+    /// Huawei JKM-LX3 chain whose leaf carries a CRL distribution point that does not parse.
+    #[allow(dead_code)]
+    const LEGACY_UNPARSABLE_CRL_DISTRIBUTION_POINT_CHAIN: [&str; 4] = [
+        "MIICgzCCAimgAwIBAgIBATAKBggqhkjOPQQDAjApMRkwFwYDVQQFExBjOTZmNGM4YjM3NWZlYTg0MQwwCgYDVQQMDANURUUwHhcNNzAwMTA1MDkzNzI1WhcNMjYwNzI2MjAzMDAxWjAfMR0wGwYDVQQDExRBbmRyb2lkIEtleXN0b3JlIEtleTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIjjh9yczy/sUhmVj1c3JkXjOPjxlDeW8+NaQRbCx7EukA9x16CwFWYOHOgIsp0eSmEbplws4yQT+vrCFtaoBSejggFKMIIBRjALBgNVHQ8EBAMCB4AwCAYDVR0fBAEAMIIBKwYKKwYBBAHWeQIBEQSCARswggEXAgECCgEBAgEDCgEBBC5uPTZlYjUzOGZiMTIwNGU3N2RmNDI3NjFhODZhMDlkZGJkLGF2PTQuMC4zMjAxBAAwRL+FRUAEPjA8MRYwFAQNY29tLndvcmxkY29pbgIDPRWBMSIEIJ0q1xJ/CZGSlxTAGVtDR4Q0UxzYt/GBNlwr1c2F40bvMIGQoQUxAwIBAqIDAgEDowQCAgEApQgxBgIBAAIBBKoDAgEBv4MRCAIGAZ+gHs0ov4MSCAIGAZ+gHs0ov4N3AgUAv4U9BgIEFqoVab+FPgMCAQC/hUAqMCgEIFNB5rJkaXmnDldlMAeh8xAWlCHsm92fGlZI91reAFrxAQH/CgEAv4VBBQIDAV+Qv4VCBQIDAxUYMAoGCCqGSM49BAMCA0gAMEUCIQDCXMDWHlPo4444yWBCb8z7J/ZiHKZZlBnHODFy73MQ7QIgAlCg4VqQJmyNWZq/HPS71n98DOmtuz23FjRlNqVzCpc=",
+        "MIICJjCCAaugAwIBAgIKBSBEl1CTJzaJCTAKBggqhkjOPQQDAjApMRkwFwYDVQQFExAxZGY0ZTA2YTZjNDJmNjUxMQwwCgYDVQQMDANURUUwHhcNMTkwNDE5MjA1MDM1WhcNMjkwNDE2MjA1MDM1WjApMRkwFwYDVQQFExBjOTZmNGM4YjM3NWZlYTg0MQwwCgYDVQQMDANURUUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQlQKIAGRp6nAleLLXM+WThYarEsbeLbu8kRVJQ7VpWEamG8Ul1emeGTgTZfPZTY3mViqt0CDwx9l7CNRSoohKro4G6MIG3MB0GA1UdDgQWBBTtnzKLJR+08iOYND048mz8wLqTmDAfBgNVHSMEGDAWgBRqgbARQ6Cxo+9uCtUBhAAuSsUqsTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDBUBgNVHR8ETTBLMEmgR6BFhkNodHRwczovL2FuZHJvaWQuZ29vZ2xlYXBpcy5jb20vYXR0ZXN0YXRpb24vY3JsLzA1MjA0NDk3NTA5MzI3MzY4OTA5MAoGCCqGSM49BAMCA2kAMGYCMQC3U5YUtLat6GaU2Aie1s13jIcozPADMfipSLHXsROEAqL3WOjgN4L55ihkVNnx0/oCMQCRFvBVfdVoJLZaY9kvxB5BOj3S/u43W9Eb/iilTqpOT9bwZVNX+yR4Fs/x/TaqFEQ=",
+        "MIID0TCCAbmgAwIBAgIKA4gmZ2BliZaF2jANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MB4XDTE5MDQxOTIwMzUxOVoXDTI5MDQxNjIwMzUxOVowKTEZMBcGA1UEBRMQMWRmNGUwNmE2YzQyZjY1MTEMMAoGA1UEDAwDVEVFMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEdg8tZ4Tz9D9IFMefEvOM+s+nLky2cm1bdTjvgiVkG4LMKAWle7EyW3wnh810aPohcFgYBrBvKCZlmjz8NMv/SxRBYWGO/7NovnT/HLOi0e3Eeos1eg+bS9TLY9m8r1kmo4G2MIGzMB0GA1UdDgQWBBRqgbARQ6Cxo+9uCtUBhAAuSsUqsTAfBgNVHSMEGDAWgBQ2YeEAfIgFCVGLRGxH/xpMyepPEjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDBQBgNVHR8ESTBHMEWgQ6BBhj9odHRwczovL2FuZHJvaWQuZ29vZ2xlYXBpcy5jb20vYXR0ZXN0YXRpb24vY3JsL0U4RkExOTYzMTREMkZBMTgwDQYJKoZIhvcNAQELBQADggIBAFPT8lzyoVECUHxpmXWdOqC6eIgxELe9EkEEoZ+kyFGEWKYItJ3P1SHREBPmgXdP5zVYP6Ai0f1c88Hl2DAnDZQ5VmnY08O/GxoP7t/t3Pa26TOnG1dxxNIU9iPwY+3Rry9GmwSRk5BC6PSaXUZ1tsKSeJBNAONnAnaJin+9M0tK8wRRgyFFBVhZtgOLNPGUMDsNUAqpw/mH1JFbAGZ6lIp1p6/t/+sVFmsAMS+X4ZDJ5Lv3wiK0wfsXhV9aq8G7GCMdebk66fsNLze86kPb/kgwzQp+PyeOUmCJmPmNGtoZW9grx0P/kdSzNb7rX4fzzSNW2+J2EmWsj1qfLPUc5BNsupBgcUq2v0pM6+/W81RyrNTnALSvU50rILjB5ov6wuGYxNxTNO5qkI/A9exa+VFtijr98U6Qb6DczI5CU9dJbDO49JJBeXBKwFsxtnuow0jL8SC/KRUyECC1cjpO6FgkNuJUr5zuwOMbgi4hoCOZSOl6KfYeOokLVn38zEPzc3EXE3+BkZsSi0Mhtcv30dcRR//2RdTZ67YDzHcPJbmqMDaUgDb18cKR1jI/9HYeYNJs8q2iiocDBwEHprRK+LVRCvu/3sBoQOePJ6DRdoHkLyl3UCfJW6gpvWig/EUfLwo2HxDfB2mIoxfi1DhCdEb6cfihod0NVm1TQzekh7s+",
+        "MIIFYDCCA0igAwIBAgIJAOj6GWMU0voYMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNVBAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTYwNTI2MTYyODUyWhcNMjYwNTI0MTYyODUyWjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdSSxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggjnar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGqC4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQoVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+OJtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/EgsTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRiigHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+MRPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9EaDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5UmAGMCAwEAAaOBpjCBozAdBgNVHQ4EFgQUNmHhAHyIBQlRi0RsR/8aTMnqTxIwHwYDVR0jBBgwFoAUNmHhAHyIBQlRi0RsR/8aTMnqTxIwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwQAYDVR0fBDkwNzA1oDOgMYYvaHR0cHM6Ly9hbmRyb2lkLmdvb2dsZWFwaXMuY29tL2F0dGVzdGF0aW9uL2NybC8wDQYJKoZIhvcNAQELBQADggIBACDIw41L3KlXG0aMiS//cqrG+EShHUGo8HNsw30W1kJtjn6UBwRM6jnmiwfBPb8VA91chb2vssAtX2zbTvqBJ9+LBPGCdw/E53Rbf86qhxKaiAHOjpvAy5Y3m00mqC0w/Zwvju1twb4vhLaJ5NkUJYsUS7rmJKHHBnETLi8GFqiEsqTWpG/6ibYCv7rYDBJDcR9W62BW9jfIoBQcxUCUJouMPH25lLNcDc1ssqvC2v7iUgI9LeoM1sNovqPmQUiG9rHli1vXxzCyaMTjwftkJLkf6724DFhuKug2jITV0QkXvaJWF4nUaHOTNA4uJU9WDvZLI1j83A+/xnAJUucIv/zGJ1AMH2boHqF8CY16LpsYgBt6tKxxWH00XcyDCdW2KlBCeqbQPcsFmWyWugxdcekhYsAWyoSf818NUsZdBWBaR/OukXrNLfkQ79IyZohZbvabO/X+MVT3rriAoKc8oE2Uws6DF+60PV7/WIPjNvXySdqspImSN78mflxDqwLqRBYkA3I75qppLGG9rp7UCdRjxMl8ZDBld+7yvHVgt1cVzJx9xnyGCC23UaicMDSXYrB4I4WHXPGjxhZuCuPBLTdOLU8YRvMYdEvYebWHMpvwGCF6bAx3JBpIeOQ1wDB5y0USicV3YgYGmi+NZfhA4URSh77Yd6uuJOJENRaNVTzk",
+    ];
+
+    /// Xiaomi Mi A1 chain that terminates at the AOSP software attestation root.
+    #[allow(dead_code)]
+    const SOFTWARE_ATTESTATION_ROOT_CHAIN: [&str; 3] = [
+        "MIICvDCCAmOgAwIBAgIBATAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAoMDEdvb2dsZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDE7MDkGA1UEAwwyQW5kcm9pZCBLZXlzdG9yZSBTb2Z0d2FyZSBBdHRlc3RhdGlvbiBJbnRlcm1lZGlhdGUwHhcNNzAwMTAxMDAwMDAwWhcNMjYwNzI2MDkxMzE3WjAfMR0wGwYDVQQDDBRBbmRyb2lkIEtleXN0b3JlIEtleTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDwfwcvfx+bm6M5xJV0cVz1bqVc+wzGiVyI3YCatEYthd8F1ULgGC2SkwAH/Mu79p4rkpWYXtzG5ZEDUIzgLCjmjggEkMIIBIDALBgNVHQ8EBAMCB4Awge8GCisGAQQB1nkCAREEgeAwgd0CAQIKAQACAQEKAQEELm49MzMxMmNkOTZmMWMzYWFlYzFlMGJkNTc1NjU0OWY1YjcsYXY9NC4wLjMyMDEEADBnv4MRCAIGAZ+dszvIv4MSCAIGAZ+dszvIv4U9BwIFAJ2up+i/hUVABD4wPDEWMBQEDWNvbS53b3JsZGNvaW4CAz0VgTEiBCCdKtcSfwmRkpcUwBlbQ0eENFMc2LfxgTZcK9XNheNG7zA0oQUxAwIBAqIDAgEDowQCAgEApQgxBgIBAAIBBKoDAgEBv4N3AgUAv4U+AwIBAL+FPwIFADAfBgNVHSMEGDAWgBQ//KzWGrE6noEguNUlHMVlux6RqTAKBggqhkjOPQQDAgNHADBEAiBNbGebm9J763fRXMNZ+fAk8ofle1UHJ1+1QO7xA0GuYQIgYPeZJ97WOwFgVcEsr+mWXu0oRhA7hcPoU1Upcvk2wzQ=",
+        "MIICeDCCAh6gAwIBAgICEAEwCgYIKoZIzj0EAwIwgZgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1Nb3VudGFpbiBWaWV3MRUwEwYDVQQKDAxHb29nbGUsIEluYy4xEDAOBgNVBAsMB0FuZHJvaWQxMzAxBgNVBAMMKkFuZHJvaWQgS2V5c3RvcmUgU29mdHdhcmUgQXR0ZXN0YXRpb24gUm9vdDAeFw0xNjAxMTEwMDQ2MDlaFw0yNjAxMDgwMDQ2MDlaMIGIMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMTswOQYDVQQDDDJBbmRyb2lkIEtleXN0b3JlIFNvZnR3YXJlIEF0dGVzdGF0aW9uIEludGVybWVkaWF0ZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABOueefhCY1msyyqRTImGzHCtkGaTgqlzJhP+rMv4ISdMIXSXSir+pblNf2bU4GUQZjW8U7ego6ZxWD7bPhGuEBSjZjBkMB0GA1UdDgQWBBQ//KzWGrE6noEguNUlHMVlux6RqTAfBgNVHSMEGDAWgBTIrel3TEXDo88NFhDkeUM6IVowzzASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIChDAKBggqhkjOPQQDAgNIADBFAiBLipt77oK8wDOHri/AiZi03cONqycqRZ9pDMfDktQPjgIhAO7aAV229DLp1IQ7YkyUBO86fMy9Xvsiu+f+uXc/WT/7",
+        "MIICizCCAjKgAwIBAgIJAKIFntEOQ1tXMAoGCCqGSM49BAMCMIGYMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzEVMBMGA1UECgwMR29vZ2xlLCBJbmMuMRAwDgYDVQQLDAdBbmRyb2lkMTMwMQYDVQQDDCpBbmRyb2lkIEtleXN0b3JlIFNvZnR3YXJlIEF0dGVzdGF0aW9uIFJvb3QwHhcNMTYwMTExMDA0MzUwWhcNMzYwMTA2MDA0MzUwWjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxFTATBgNVBAoMDEdvb2dsZSwgSW5jLjEQMA4GA1UECwwHQW5kcm9pZDEzMDEGA1UEAwwqQW5kcm9pZCBLZXlzdG9yZSBTb2Z0d2FyZSBBdHRlc3RhdGlvbiBSb290MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7l1ex+HA220Dpn7mthvsTWpdamguD/9/SQ59dx9EIm29sa/6FsvHrcV30lacqrewLVQBXT5DKyqO107sSHVBpKNjMGEwHQYDVR0OBBYEFMit6XdMRcOjzw0WEOR5QzohWjDPMB8GA1UdIwQYMBaAFMit6XdMRcOjzw0WEOR5QzohWjDPMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgKEMAoGCCqGSM49BAMCA0cAMEQCIDUho++LNEYenNVg8x1YiSBq3KNlQfYNns6KGYxmSGB7AiBNC/NR2TB8fVvaNTQdqEcbY6WFZTytTySn502vQX3xvw==",
+    ];
+
+    #[allow(dead_code)]
+    fn decode_chain(chain: &[&str]) -> Vec<X509> {
+        chain
+            .iter()
+            .map(|cert| X509::from_der(&Base64.decode(cert).unwrap()).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn accepts_legacy_factory_chain_with_non_ca_attestation_certificate() {
+        let cert_chain_builder = CertChainBuilder::new_from_default_pem().unwrap();
+
+        // OpenSSL rejects this chain with "invalid CA certificate at depth 1" because the
+        // factory attestation certificate is marked CA:FALSE. Google's verifier does not look
+        // at basicConstraints, and every link is signed correctly up to the pinned root.
+        cert_chain_builder
+            .build_chain_from_base64(&LEGACY_NON_CA_INTERMEDIATE_CHAIN.map(str::to_string))
+            .unwrap();
+    }
+
+    #[test]
+    fn accepts_legacy_factory_chain_with_unparsable_crl_distribution_point() {
+        let cert_chain_builder = CertChainBuilder::new_from_default_pem().unwrap();
+
+        // The leaf carries a CRL distribution point whose value is a single zero byte. OpenSSL
+        // marks the whole certificate invalid and reports a missing issuer at depth 0, even
+        // though the issuer is present in the chain. We never read that extension; revocation
+        // is checked against Google's status list instead.
+        cert_chain_builder
+            .build_chain_from_base64(
+                &LEGACY_UNPARSABLE_CRL_DISTRIBUTION_POINT_CHAIN.map(str::to_string),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn google_rules_fallback_rejects_chains_that_do_not_reach_the_pinned_root() {
+        let cert_chain_builder = CertChainBuilder::new_from_default_pem().unwrap();
+        let cert_chain = decode_chain(&SOFTWARE_ATTESTATION_ROOT_CHAIN);
+
+        // Every link in this chain is internally consistent, so root pinning is the only thing
+        // rejecting it. The software attestation root's private key ships in AOSP, so accepting
+        // it would make attestation forgeable by anyone.
+        assert!(
+            !cert_chain_builder
+                .legacy_chain_matches_google_rules(&cert_chain)
+                .unwrap()
+        );
+
+        assert!(
+            cert_chain_builder
+                .build_chain_from_base64(&SOFTWARE_ATTESTATION_ROOT_CHAIN.map(str::to_string))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_chain_carrying_an_attestation_extension_below_the_leaf() {
+        // The Google rules fallback no longer relies on basicConstraints to stop a caller
+        // extending a chain with a forged leaf, so the guard that only the leaf may carry an
+        // attestation extension has to hold on its own.
+        let cert_chain = decode_chain(&LEGACY_NON_CA_INTERMEDIATE_CHAIN);
+        let [leaf, attestation, intermediate, root] = cert_chain.as_slice() else {
+            panic!("fixture should contain four certificates");
+        };
+
+        let extended_chain = [
+            leaf.clone(),
+            leaf.clone(),
+            attestation.clone(),
+            intermediate.clone(),
+            root.clone(),
+        ];
+
+        let error = CertChain::from_x509(&extended_chain)
+            .err()
+            .expect("an attestation extension below the leaf must be rejected");
+
+        assert!(matches!(
+            error,
+            CertChainError::IntermediateCert(IntermediateCertError::AttestationPresent)
+        ));
     }
 
     #[test]

--- a/attestation-gateway/src/android/cert_chain_builder.rs
+++ b/attestation-gateway/src/android/cert_chain_builder.rs
@@ -457,6 +457,10 @@ mod tests {
             .unwrap();
     }
 
+    /// Serial of the 2016 legacy Google attestation root, which both fixtures terminate at.
+    #[allow(dead_code)]
+    const LEGACY_GOOGLE_ROOT_SERIAL_HEX: &str = "e8fa196314d2fa18";
+
     /// Sony SOV37 chain whose factory attestation certificate is marked CA:FALSE.
     #[allow(dead_code)]
     const LEGACY_NON_CA_INTERMEDIATE_CHAIN: [&str; 4] = [
@@ -498,9 +502,30 @@ mod tests {
         // OpenSSL rejects this chain with "invalid CA certificate at depth 1" because the
         // factory attestation certificate is marked CA:FALSE. Google's verifier does not look
         // at basicConstraints, and every link is signed correctly up to the pinned root.
-        cert_chain_builder
+        assert!(
+            cert_chain_builder
+                .legacy_chain_matches_google_rules(&decode_chain(&LEGACY_NON_CA_INTERMEDIATE_CHAIN))
+                .unwrap()
+        );
+
+        let cert_chain = cert_chain_builder
             .build_chain_from_base64(&LEGACY_NON_CA_INTERMEDIATE_CHAIN.map(str::to_string))
             .unwrap();
+
+        // Pin what was accepted, not just that nothing errored: the chain must still be ordered
+        // leaf to root and must terminate at the legacy Google root.
+        assert_eq!(
+            cert_chain.root_cert().serial().hex,
+            LEGACY_GOOGLE_ROOT_SERIAL_HEX
+        );
+        assert_eq!(
+            cert_chain.root_cert().serial().issued_to,
+            vec![String::from_utf8_lossy(LEGACY_GOOGLE_ROOT_SERIAL).to_string()],
+        );
+        assert_eq!(
+            cert_chain.device_cert().serial().issued_to,
+            vec!["5a75218acd7a00f8".to_string()],
+        );
     }
 
     #[test]
@@ -511,11 +536,28 @@ mod tests {
         // marks the whole certificate invalid and reports a missing issuer at depth 0, even
         // though the issuer is present in the chain. We never read that extension; revocation
         // is checked against Google's status list instead.
-        cert_chain_builder
+        assert!(
+            cert_chain_builder
+                .legacy_chain_matches_google_rules(&decode_chain(
+                    &LEGACY_UNPARSABLE_CRL_DISTRIBUTION_POINT_CHAIN,
+                ))
+                .unwrap()
+        );
+
+        let cert_chain = cert_chain_builder
             .build_chain_from_base64(
                 &LEGACY_UNPARSABLE_CRL_DISTRIBUTION_POINT_CHAIN.map(str::to_string),
             )
             .unwrap();
+
+        assert_eq!(
+            cert_chain.root_cert().serial().hex,
+            LEGACY_GOOGLE_ROOT_SERIAL_HEX
+        );
+        assert_eq!(
+            cert_chain.device_cert().serial().issued_to,
+            vec!["c96f4c8b375fea84".to_string()],
+        );
     }
 
     #[test]


### PR DESCRIPTION
[SEC-2830](https://linear.app/worldcoin/issue/SEC-2830/attestation-gateway-accept-legacy-factory-chains-rejected-by-openssl) has the analysis and rationale.

## Summary

Extends the legacy fallback added in #216. When OpenSSL rejects a legacy factory-provisioned chain, validate it with Google's rule set instead: canonical issuer to subject name chaining, a signature check on every link, and a terminal certificate pinned by public key. This mirrors Google's own [KeyAttestationCertPathValidator](https://github.com/android/keyattestation/blob/main/src/main/kotlin/provider/KeyAttestationCertPathValidator.kt), which exists because older devices emit chains that do not fully conform to RFC 5280.

Strict OpenSSL validation stays the primary path, RKP chains are untouched, and root pinning is unchanged.

Two chain shapes are covered, both of which already verify cleanly up to the pinned Google root:

- a factory attestation certificate marked `CA:FALSE` that still signs the leaf
- a leaf whose CRL distribution point does not parse

## Test plan

- [x] Accept tests for both chain shapes, asserting the accepted chain's root and device certificate rather than only that no error was returned
- [x] Reject test for a chain that does not reach the pinned root
- [x] Reject test for an attestation extension below the leaf
- [x] `cargo fmt --all -- --check` clean, no new clippy findings in the changed file
- [x] `cargo test --lib` matches the `origin/main` baseline with four more passing tests

Fixture chains are production-derived, consistent with #216. They contain no private key material and no ID attestation tags.
