### PR TITLE
Audicence mismatch is not a server error - log as warn

### DIFF
--- a/attestation-gateway/src/routes/c.rs
+++ b/attestation-gateway/src/routes/c.rs
@@ -59,7 +59,7 @@ pub async fn handler(
         .await
         .map_err(|error| {
             if matches!(error, AudienceAuthorizationError::NotAuthorized) {
-                tracing::error!(
+                tracing::warn!(
                     aud = %request.aud,
                     endpoint = "/c",
                     session_id = %session_id,


### PR DESCRIPTION
[Log](https://app.datadoghq.com/logs?query=service%3Aattestation-gateway%20env%3Aproduction%20%40level%3AERROR%20%22Audience%20is%20not%20authorized%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40classification%2C%40aud&link_event_id=8749421495611648553&link_event_ts=1785768965&link_monitor_id=151894325&link_source=monitor_notif&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1785745294037&to_ts=1785831694037&live=false)

<img width="3300" height="1590" alt="image" src="https://github.com/user-attachments/assets/6451e3b1-82a8-4fa7-9fad-1c89876a06fc" />
