### PR TITLE
Harden Kinesis PutRecord against transient AWS failures

### DIFF
--- a/attestation-gateway/src/kinesis.rs
+++ b/attestation-gateway/src/kinesis.rs
@@ -6,6 +6,7 @@ use aws_sdk_kinesis::{
     operation::put_record::PutRecordError,
     primitives::Blob,
 };
+use uuid::Uuid;
 
 use crate::utils::DataReport;
 
@@ -23,9 +24,8 @@ pub async fn send_kinesis_stream_event(
     stream_arn: &str,
     data_report: &DataReport,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Get the partition key from the DataReport using the bundle identifier
-    let partition_key = data_report.bundle_identifier.to_string();
-
+    // Generate a unique partition key for the DataReport
+    let partition_key = Uuid::new_v4().simple().to_string();
     // Serialize DataReport to JSON
     let payload_bytes = data_report.as_vec()?;
 

--- a/attestation-gateway/src/kinesis.rs
+++ b/attestation-gateway/src/kinesis.rs
@@ -1,28 +1,79 @@
-use crate::utils::DataReport;
-use aws_sdk_kinesis::{Client as KinesisClient, primitives::Blob};
+use std::time::Duration;
 
-/// Reports a parsed event to a Kinesis stream for debugging and monitoring purposes
+use aws_sdk_kinesis::{
+    Client as KinesisClient,
+    error::{ProvideErrorMetadata, SdkError},
+    operation::put_record::PutRecordError,
+    primitives::Blob,
+};
+
+use crate::utils::DataReport;
+
+const MAX_ATTEMPTS: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 50;
+
+/// Reports a parsed event to a Kinesis stream for debugging and monitoring purposes.
+///
+/// Retries a few times with exponential backoff on transient AWS failures.
 ///
 /// # Errors
-/// Will return an `aws_sdk_kinesis::Error` if the request to Kinesis fails.
+/// Will return an error if serialization fails or PutRecord still fails after retries.
 pub async fn send_kinesis_stream_event(
     kinesis_client: &KinesisClient,
     stream_arn: &str,
     data_report: &DataReport,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let partition_key: &str = "id";
+    let (payload_bytes, partition_key) = data_report.as_vec()?;
 
-    // Serialize DataReport to JSON
-    let payload_bytes = data_report.as_vec()?;
+    let mut backoff_ms = INITIAL_BACKOFF_MS;
 
-    // Send the serialized data to Kinesis
-    kinesis_client
-        .put_record()
-        .stream_arn(stream_arn)
-        .partition_key(partition_key)
-        .data(Blob::new(payload_bytes))
-        .send()
-        .await?;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match kinesis_client
+            .put_record()
+            .stream_arn(stream_arn)
+            .partition_key(&partition_key)
+            .data(Blob::new(payload_bytes.clone()))
+            .send()
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(error) => {
+                if !is_retryable_put_record_error(&error) || attempt == MAX_ATTEMPTS {
+                    return Err(error.into());
+                }
 
-    Ok(())
+                tracing::debug!(
+                    attempt,
+                    backoff_ms,
+                    error = ?error,
+                    "Retrying Kinesis PutRecord after transient failure"
+                );
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                backoff_ms = backoff_ms.saturating_mul(2);
+            }
+        }
+    }
+
+    unreachable!("loop returns on success or final failure")
+}
+
+fn is_retryable_put_record_error(error: &SdkError<PutRecordError>) -> bool {
+    match error {
+        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) | SdkError::ResponseError(_) => {
+            true
+        }
+        SdkError::ServiceError(context) => {
+            let retryable_code = matches!(
+                ProvideErrorMetadata::code(context.err()),
+                Some(
+                    "InternalFailure"
+                        | "ServiceUnavailable"
+                        | "ProvisionedThroughputExceededException"
+                        | "LimitExceededException"
+                )
+            );
+            retryable_code || context.raw().status().as_u16() >= 500
+        }
+        _ => false,
+    }
 }

--- a/attestation-gateway/src/kinesis.rs
+++ b/attestation-gateway/src/kinesis.rs
@@ -23,7 +23,11 @@ pub async fn send_kinesis_stream_event(
     stream_arn: &str,
     data_report: &DataReport,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (payload_bytes, partition_key) = data_report.as_vec()?;
+    // Get the partition key from the DataReport using the bundle identifier
+    let partition_key = data_report.bundle_identifier.to_string();
+
+    // Serialize DataReport to JSON
+    let payload_bytes = data_report.as_vec()?;
 
     let mut backoff_ms = INITIAL_BACKOFF_MS;
 

--- a/attestation-gateway/src/routes/generate_token.rs
+++ b/attestation-gateway/src/routes/generate_token.rs
@@ -346,11 +346,12 @@ async fn process_and_finalize_report(
     kinesis_client: &KinesisClient,
     kinesis_stream_arn: &str,
 ) -> Result<TokenGenerationResponse, RequestError> {
-    // Report result to Kinesis
+    // Report result to Kinesis (best-effort analytics; never fail the request)
     if !kinesis_stream_arn.is_empty()
         && let Err(e) = send_kinesis_stream_event(kinesis_client, kinesis_stream_arn, &report).await
     {
-        tracing::error!("Failed to send Kinesis event: {:?}", e);
+        metrics::counter!("attestation_gateway.kinesis_put_failure").increment(1);
+        tracing::warn!(error = ?e, "Failed to send Kinesis event");
     }
 
     // TODO: Initial roll out does not include generating failure tokens
@@ -450,15 +451,11 @@ async fn handle_client_error_if_applicable(
             Some("`client_error` provided in the request".to_string()),
         );
 
-        send_kinesis_stream_event(kinesis_client, kinesis_stream_arn, &report)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to send `client_error` to Kinesis: {:?}", e);
-                RequestError {
-                    code: ErrorCode::InternalServerError,
-                    details: None,
-                }
-            })?;
+        if let Err(e) = send_kinesis_stream_event(kinesis_client, kinesis_stream_arn, &report).await
+        {
+            metrics::counter!("attestation_gateway.kinesis_put_failure").increment(1);
+            tracing::warn!(error = ?e, "Failed to send `client_error` to Kinesis");
+        }
 
         if log_client_errors {
             tracing::info!(

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -810,8 +810,8 @@ impl DataReport {
 
     /// Formats the `DataReport` as a JSON object and serializes it to a byte vector.
     ///
-    /// This method generates a random identifier embedded in the payload as `report_{uuid}`
-    /// because the `request_hash` is deleted after some time.
+    /// This method generates a random identifier to act as partition key for the Kinesis stream.
+    /// This is used because the `request_hash` is deleted after some time.
     ///
     /// # Errors
     /// Will return an `eyre::Error` if the serialization fails.

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -810,24 +810,26 @@ impl DataReport {
 
     /// Formats the `DataReport` as a JSON object and serializes it to a byte vector.
     ///
-    /// This method generates a random identifier to act as partition key for the Kinesis stream.
-    /// This is used because the `request_hash` is deleted after some time.
+    /// Returns `(payload_bytes, partition_key)`. The partition key is a random UUID so
+    /// records spread across shards; the same id is embedded in the payload as
+    /// `report_{uuid}` because `request_hash` is deleted after some time.
     ///
     /// # Errors
     /// Will return an `eyre::Error` if the serialization fails.
-    pub fn as_vec(&self) -> eyre::Result<Vec<u8>> {
+    pub fn as_vec(&self) -> eyre::Result<(Vec<u8>, String)> {
         let mut payload = serde_json::to_value(self)?;
         let obj = payload
             .as_object_mut()
             .ok_or_else(|| eyre::eyre!("Error serializing DataReport as JSON object"))?;
 
-        let id = Uuid::new_v4().simple().to_string();
+        let partition_key = Uuid::new_v4().simple().to_string();
         obj.insert(
             "id".to_string(),
-            serde_json::Value::String(format!("report_{id}")),
+            serde_json::Value::String(format!("report_{partition_key}")),
         );
 
-        serde_json::to_vec(&payload).map_err(Into::into)
+        let bytes = serde_json::to_vec(&payload)?;
+        Ok((bytes, partition_key))
     }
 }
 

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -810,26 +810,24 @@ impl DataReport {
 
     /// Formats the `DataReport` as a JSON object and serializes it to a byte vector.
     ///
-    /// Returns `(payload_bytes, partition_key)`. The partition key is a random UUID so
-    /// records spread across shards; the same id is embedded in the payload as
-    /// `report_{uuid}` because `request_hash` is deleted after some time.
+    /// This method generates a random identifier to act as partition key for the Kinesis stream.
+    /// This is used because the `request_hash` is deleted after some time.
     ///
     /// # Errors
     /// Will return an `eyre::Error` if the serialization fails.
-    pub fn as_vec(&self) -> eyre::Result<(Vec<u8>, String)> {
+    pub fn as_vec(&self) -> eyre::Result<Vec<u8>> {
         let mut payload = serde_json::to_value(self)?;
         let obj = payload
             .as_object_mut()
             .ok_or_else(|| eyre::eyre!("Error serializing DataReport as JSON object"))?;
 
-        let partition_key = Uuid::new_v4().simple().to_string();
+        let id = Uuid::new_v4().simple().to_string();
         obj.insert(
             "id".to_string(),
-            serde_json::Value::String(format!("report_{partition_key}")),
+            serde_json::Value::String(format!("report_{id}")),
         );
 
-        let bytes = serde_json::to_vec(&payload)?;
-        Ok((bytes, partition_key))
+        serde_json::to_vec(&payload).map_err(Into::into)
     }
 }
 

--- a/attestation-gateway/src/utils.rs
+++ b/attestation-gateway/src/utils.rs
@@ -810,8 +810,8 @@ impl DataReport {
 
     /// Formats the `DataReport` as a JSON object and serializes it to a byte vector.
     ///
-    /// This method generates a random identifier to act as partition key for the Kinesis stream.
-    /// This is used because the `request_hash` is deleted after some time.
+    /// This method generates a random identifier embedded in the payload as `report_{uuid}`
+    /// because the `request_hash` is deleted after some time.
     ///
     /// # Errors
     /// Will return an `eyre::Error` if the serialization fails.

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -2148,7 +2148,12 @@ async fn test_client_error_gets_logged_to_kinesis() {
         .unwrap();
 
     let record = response.records[0].clone();
-    assert_eq!(record.partition_key, "id");
+    let partition_key_re = Regex::new(r"^[0-9a-f]{32}$").unwrap();
+    assert!(
+        partition_key_re.is_match(&record.partition_key),
+        "Kinesis partition key should be a UUID, got {}",
+        record.partition_key
+    );
     let record_body = String::from_utf8(record.data.into_inner()).unwrap();
 
     let json_body = serde_json::from_str::<Value>(&record_body).unwrap();
@@ -2157,6 +2162,10 @@ async fn test_client_error_gets_logged_to_kinesis() {
     assert!(
         re.is_match(json_body["id"].as_str().unwrap()),
         "Kinesis DataReport.id format is incorrect"
+    );
+    assert_eq!(
+        json_body["id"].as_str().unwrap(),
+        format!("report_{}", record.partition_key)
     );
 
     let data_report: DataReport = serde_json::from_str(&record_body).unwrap();

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -2148,9 +2148,11 @@ async fn test_client_error_gets_logged_to_kinesis() {
         .unwrap();
 
     let record = response.records[0].clone();
-    assert_eq!(
-        record.partition_key,
-        BundleIdentifier::ComWorldcoinStaging.to_string()
+    let partition_key_re = Regex::new(r"^[0-9a-f]{32}$").unwrap();
+    assert!(
+        partition_key_re.is_match(&record.partition_key),
+        "Kinesis partition key should be a UUID, got {}",
+        record.partition_key
     );
     let record_body = String::from_utf8(record.data.into_inner()).unwrap();
 

--- a/attestation-gateway/tests/generate_token_integration.rs
+++ b/attestation-gateway/tests/generate_token_integration.rs
@@ -2148,11 +2148,9 @@ async fn test_client_error_gets_logged_to_kinesis() {
         .unwrap();
 
     let record = response.records[0].clone();
-    let partition_key_re = Regex::new(r"^[0-9a-f]{32}$").unwrap();
-    assert!(
-        partition_key_re.is_match(&record.partition_key),
-        "Kinesis partition key should be a UUID, got {}",
-        record.partition_key
+    assert_eq!(
+        record.partition_key,
+        BundleIdentifier::ComWorldcoinStaging.to_string()
     );
     let record_body = String::from_utf8(record.data.into_inner()).unwrap();
 
@@ -2162,10 +2160,6 @@ async fn test_client_error_gets_logged_to_kinesis() {
     assert!(
         re.is_match(json_body["id"].as_str().unwrap()),
         "Kinesis DataReport.id format is incorrect"
-    );
-    assert_eq!(
-        json_body["id"].as_str().unwrap(),
-        format!("report_{}", record.partition_key)
     );
 
     let data_report: DataReport = serde_json::from_str(&record_body).unwrap();


### PR DESCRIPTION
<img width="1669" height="928" alt="Screenshot 2026-08-04 at 10 49 32" src="https://github.com/user-attachments/assets/f2ce53cc-8ecb-4ac3-9cdf-ceb4ba8e2a58" />


## Summary

- Fix hot-shard bug: PutRecord now uses a UUID partition key instead of the literal `"id"`.
- Retry transient Kinesis failures (`InternalFailure`, throttling, 5xx, timeouts) with short exponential backoff.
- Never fail `/g` requests when analytics PutRecord fails (including the `client_error` path); log at warn and emit `attestation_gateway.kinesis_put_failure`.

## Test plan
- [x] Confirm unit/integration tests pass, especially `test_client_error_gets_logged_to_kinesis` (partition key is UUID, payload `id` is `report_{uuid}`).
- [ ] Deploy/stage and verify a normal `/g` success still lands in Kinesis across shards.
- [ ] Simulate or observe AWS blips: failures should warn (not error) and not return 500 on `client_error` requests.